### PR TITLE
fix: cwd is not a function

### DIFF
--- a/packages/cordis/src/index.ts
+++ b/packages/cordis/src/index.ts
@@ -19,7 +19,7 @@ export class Context extends core.Context {
 
   constructor(config?: any) {
     super(config)
-    this.baseDir = globalThis.process?.cwd() || ''
+    this.baseDir = globalThis.process?.cwd?.() || ''
 
     this.provide('logger', undefined, true)
     this.provide('timer', undefined, true)


### PR DESCRIPTION
This commit fixes `TypeError: process.cwd is not a function` in browser environment