### PR TITLE
fix(core): harden terminal disposal

### DIFF
--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -75,6 +75,54 @@ interface EffectRunner<T> {
   getOuterStack: () => string[]
 }
 
+// Public effect disposers remain single-shot, but structural owners and outer
+// effects must still be able to join a cleanup that another caller started.
+const effectInertia = new WeakMap<Disposable, () => void | Promise<void>>()
+
+interface CheckedDisposalAudit {
+  errors: unknown[]
+  task: Promise<void>
+}
+
+interface ActiveUnloadDiagnostics {
+  errors: unknown[]
+}
+
+// Ordinary Cordis disposal deliberately contains effect failures. A terminal
+// root owner can opt into one checked audit without changing HMR/plugin
+// semantics; nested fibers find the same root-keyed collector while unloading.
+const checkedDisposalAudits = new WeakMap<Context, CheckedDisposalAudit>()
+const activeUnloadDiagnostics = new WeakMap<Context, Set<ActiveUnloadDiagnostics>>()
+
+function recordCheckedDisposalError(ctx: Context, error: unknown): void {
+  checkedDisposalAudits.get(ctx.root)?.errors.push(error)
+}
+
+function runDisposable(dispose: Disposable) {
+  const result = dispose()
+  return effectInertia.get(dispose)?.() ?? result
+}
+
+/** Notify plugin teardown without allowing one observer to break ownership cleanup. */
+function emitPluginDisposed(context: Context, fiber: Fiber) {
+  const args: any[] = ['internal/plugin', fiber]
+  let callbacks: Function[]
+  try {
+    callbacks = context.events.dispatch('emit', args)
+  } catch (error) {
+    context.logger.error(error)
+    return
+  }
+  for (const callback of callbacks) {
+    try {
+      const returned = callback(...args)
+      Promise.resolve(returned).catch(error => context.logger.error(error))
+    } catch (error) {
+      context.logger.error(error)
+    }
+  }
+}
+
 export const enum FiberState {
   PENDING,
   LOADING,
@@ -161,24 +209,19 @@ export class Fiber {
         collect,
       }
 
-      this.context.emit('internal/plugin', this)
-
-      for (const name of Object.keys(this.inject)) {
-        this._checkImpl(name)
-      }
-
+      let shouldRefresh = false
       this.dispose = parent.fiber.effect(() => {
         const remove = runtime.fibers.push(this)
         try {
           this.config = resolveConfig(runtime, config)
-          this._refresh()
+          shouldRefresh = true
         } catch (error) {
           this.ctx.logger.error(error)
           this._error = error
         }
         return async () => {
           this.uid = null
-          this.context.emit('internal/plugin', this)
+          emitPluginDisposed(this.context, this)
           if (this.ctx.registry.has(runtime.callback)) {
             remove()
             if (!runtime.fibers.length) {
@@ -186,6 +229,16 @@ export class Fiber {
             }
           }
           this._setEpoch(INACTIVE)
+          // A PENDING fiber can already own effects registered by an
+          // internal/plugin observer. Its epoch is still INACTIVE, so
+          // _setEpoch() has no transition to drive; explicitly unload that
+          // pre-activation work before reporting disposal complete.
+          if (!this.inertia) {
+            this._updateState(() => {
+              this.inertia = this._unload()
+              return FiberState.UNLOADING
+            })
+          }
           // `this.inertia` itself should never reject — both `_reload` and
           // `_unload` swallow their own work errors via `ctx.logger.error`.
           // If it *does* reject, the only remaining cause is the logger
@@ -197,6 +250,28 @@ export class Fiber {
           }
         }
       }, 'ctx.plugin()')
+
+      try {
+        // Publish only after the parent owns a fully assigned disposer. A
+        // synchronous observer may dispose either this fiber or its parent.
+        this.context.emit('internal/plugin', this)
+      } catch (error) {
+        // Publication failed synchronously. The disposer removes the child
+        // from both the parent and runtime before control escapes.
+        Promise.resolve(this.dispose()).catch(reason => this.ctx.logger.error(reason))
+        throw error
+      }
+
+      // Keep the initial notification's historical PENDING view. The loader
+      // may also extend `inject` in that notification, so resolve dependencies
+      // only after publication. A reentrant parent unload makes the child
+      // disposer responsible for draining any PENDING effects instead.
+      if (this.uid !== null && parent.fiber.state !== FiberState.UNLOADING) {
+        for (const name of Object.keys(this.inject)) {
+          this._checkImpl(name)
+        }
+        if (shouldRefresh) this._refresh()
+      }
     } else {
       this.uid = 0
       this.ctx = this.context = parent
@@ -224,6 +299,60 @@ export class Fiber {
   assertActive() {
     if (this.uid !== null) return
     throw new CordisError('INACTIVE_EFFECT')
+  }
+
+  /**
+   * Dispose the root tree to quiescence and reject after every contained
+   * effect-cleanup failure has been observed. Ordinary {@link dispose} keeps
+   * Cordis's failure-containing HMR semantics; process-level terminal owners
+   * use this checked form when cleanup outcome controls exit semantics.
+   * Concurrent checked calls join one audit and one root disposal.
+   *
+   * @returns a task that rejects with an `AggregateError` after disposal when
+   * any nested cleanup failed.
+   * @throws when invoked on a non-root fiber.
+   */
+  disposeChecked(): Promise<void> {
+    const root = this.context.root
+    if (root.fiber !== this) {
+      throw new TypeError('disposeChecked() is only supported on the root fiber')
+    }
+    const active = checkedDisposalAudits.get(root)
+    if (active) return active.task
+
+    // Publish a concrete join task before disposal can synchronously emit a
+    // lifecycle event. A reentrant checked caller must never observe a
+    // half-initialized audit, and terminal disposal must close effect admission
+    // before this method returns to its caller.
+    const completion = Promise.withResolvers<void>()
+    const audit: CheckedDisposalAudit = { errors: [], task: completion.promise }
+    audit.task = completion.promise.finally(() => {
+      if (checkedDisposalAudits.get(root) === audit) checkedDisposalAudits.delete(root)
+    })
+    checkedDisposalAudits.set(root, audit)
+    for (const diagnostics of activeUnloadDiagnostics.get(root) ?? []) {
+      audit.errors.push(...diagnostics.errors)
+    }
+
+    let disposal: Promise<void>
+    try {
+      disposal = this.dispose()
+    } catch (error: unknown) {
+      audit.errors.push(error)
+      disposal = Promise.resolve()
+    }
+    disposal
+      .catch((error: unknown) => { audit.errors.push(error) })
+      .then(() => {
+        if (audit.errors.length > 0) {
+          throw new AggregateError(audit.errors, 'Cordis root disposal failed')
+        }
+      })
+      .then(
+        () => completion.resolve(undefined),
+        (error: unknown) => completion.reject(error),
+      )
+    return audit.task
   }
 
   private _execute<T>(runner: EffectRunner<T>) {
@@ -276,21 +405,45 @@ export class Fiber {
   effect(execute: () => Effect, label?: string): AsyncDisposable<Promise<void>>
   effect(execute: () => Effect, label = 'anonymous'): any {
     this.assertActive()
+    if (this.state === FiberState.UNLOADING) {
+      throw new CordisError('INACTIVE_EFFECT')
+    }
 
     const disposables: Disposable[] = []
+    let disposing = false
+    let disposalTask: void | Promise<void>
     const dispose = () => {
-      let task!: void | Promise<void>
-      for (const dispose of disposables.splice(0).reverse()) {
-        if (task) {
-          task = task.then(dispose)
-        } else {
-          const result = dispose()
+      if (disposing) return disposalTask
+      disposing = true
+      const errors: unknown[] = []
+      const runOne = (disposable: Disposable): void | Promise<void> => {
+        try {
+          const result = runDisposable(disposable)
           if (isObject(result) && 'then' in result) {
-            task = result as any
+            return Promise.resolve(result as PromiseLike<void>)
+              .catch((error: unknown) => { errors.push(error) })
           }
+        } catch (error: unknown) {
+          errors.push(error)
         }
       }
-      return task
+      const finish = (): void => {
+        if (errors.length === 1) throw errors[0]
+        if (errors.length > 1) {
+          throw new AggregateError(errors, 'Cordis composite effect disposal failed')
+        }
+      }
+      let task: Promise<void> | undefined
+      for (const disposable of disposables.splice(0).reverse()) {
+        if (task === undefined) {
+          const result = runOne(disposable)
+          if (result !== undefined) task = result
+        } else {
+          task = task.then(() => runOne(disposable))
+        }
+      }
+      if (task === undefined) return finish()
+      return disposalTask = task.then(finish)
     }
 
     const meta: EffectMeta = { label, children: [] }
@@ -308,34 +461,107 @@ export class Fiber {
     }
 
     let task: void | Promise<void>
+    let executing = true
+    let resolveSetup: (() => void) | undefined
+    let rejectSetup: ((reason: unknown) => void) | undefined
+    let setupBarrier: Promise<void> | undefined
+    let setupFailed = false
+    let inFlight: void | Promise<void>
+    let removeWrapper = () => false
+
+    const waitForSetup = () => {
+      setupBarrier ??= new Promise<void>((resolve, reject) => {
+        resolveSetup = resolve
+        rejectSetup = reject
+      })
+      return setupBarrier
+    }
+
+    const disposeAfter = (setup: PromiseLike<void>) => {
+      return Promise.resolve(setup).then(
+        () => dispose(),
+        async (reason) => {
+          await dispose()
+          throw reason
+        },
+      )
+    }
+
+    const finalizeDisposal = (callback: () => void | Promise<void>) => {
+      let result: void | Promise<void>
+      try {
+        result = callback()
+      } catch (error) {
+        removeWrapper()
+        throw error
+      }
+      if (isObject(result) && 'then' in result) {
+        const pending = Promise.resolve(result).finally(() => {
+          removeWrapper()
+          if (inFlight === pending) inFlight = undefined
+        })
+        return inFlight = pending
+      }
+      removeWrapper()
+      return result
+    }
+
+    const wrapper = defineProperty(() => {
+      // A synchronous setup failure can race an owner unload that already
+      // captured this wrapper but has not invoked it yet. The failed effect is
+      // never returned publicly, so let that internal caller await rollback.
+      if (!runner.epoch) return setupFailed ? inFlight : undefined
+      runner.epoch = false
+      return finalizeDisposal(() => {
+        if (executing) return disposeAfter(waitForSetup())
+        return task ? disposeAfter(task) : dispose()
+      })
+    }, symbols.effect, meta) as AsyncDisposable
+    effectInertia.set(wrapper, () => inFlight)
+
+    // Make the effect visible to a reentrant owner unload before execute()
+    // runs any plugin code. Async teardown stays owner-visible until it
+    // settles, allowing an outer effect to join cleanup another caller began.
+    removeWrapper = this._disposables.push(wrapper)
     try {
       task = this._execute(runner)
     } catch (reason) {
-      dispose()
+      executing = false
+      setupFailed = true
+      runner.epoch = false
+      let cleanup: void | Promise<void>
+      try {
+        cleanup = finalizeDisposal(dispose)
+      } finally {
+        rejectSetup?.(reason)
+      }
+      if (isObject(cleanup) && 'then' in cleanup) {
+        cleanup.catch(error => this.ctx.logger.error(error))
+      }
       throw reason
+    }
+    executing = false
+    if (setupBarrier) {
+      Promise.resolve(task).then(resolveSetup, rejectSetup)
     }
 
     // prevent unhandled rejection — both from `task` itself and from the
     // disposer chain if it fails to settle cleanly.
-    task?.catch(dispose).catch((error) => this.ctx.logger.error(error))
-
-    const wrapper = defineProperty(() => {
-      if (!runner.epoch) return
-      runner.epoch = false
-      return task ? task.then(dispose) : dispose()
-    }, symbols.effect, meta) as AsyncDisposable
+    task?.catch(() => {
+      if (!runner.epoch) return dispose()
+      return finalizeDisposal(dispose)
+    }).catch((error) => this.ctx.logger.error(error))
 
     const disposeAsync = () => {
       if (!runner.epoch) return
       runner.epoch = false
-      return dispose()
+      return finalizeDisposal(dispose)
     }
     wrapper.then = async (onFulfilled, onRejected) => {
       return Promise.resolve(task)
         .then(() => disposeAsync)
         .then(onFulfilled, onRejected)
     }
-    disposables.push(this._disposables.push(wrapper))
     return wrapper
   }
 
@@ -417,7 +643,12 @@ export class Fiber {
     const oldEpoch = this._runner.epoch
     try {
       await Promise.resolve()
-      await this._execute(this._runner)
+      // A disposer queued before this checkpoint may already have invalidated
+      // the load. Do not run plugin code for a stale epoch; the state update
+      // below will drain any effects collected while the fiber was PENDING.
+      if (this._runner.epoch === oldEpoch) {
+        await this._execute(this._runner)
+      }
     } catch (reason) {
       // impl guarantees that the error is non-null (?)
       this.ctx.logger.error(reason)
@@ -435,26 +666,41 @@ export class Fiber {
   }
 
   private async _unload() {
-    await Promise.all(this._disposables.clear().map(async (dispose) => {
-      try {
-        await composeError(async (info) => {
-          await Promise.resolve()
-          info.error = new Error()
-          await dispose()
-        }, this._runner.getOuterStack)
-      } catch (reason) {
-        this.ctx.logger.error(reason)
-      }
-    }))
-    this.store = undefined
-    this._updateState(() => {
-      if (this._runner.epoch === INACTIVE) {
-        this.inertia = undefined
-      } else {
-        this.inertia = this._reload()
-        return FiberState.LOADING
-      }
-    })
+    const root = this.context.root
+    const diagnostics: ActiveUnloadDiagnostics = { errors: [] }
+    let active = activeUnloadDiagnostics.get(root)
+    if (active === undefined) {
+      active = new Set()
+      activeUnloadDiagnostics.set(root, active)
+    }
+    active.add(diagnostics)
+    try {
+      await Promise.all(this._disposables.clear().map(async (dispose) => {
+        try {
+          await composeError(async (info) => {
+            await Promise.resolve()
+            info.error = new Error()
+            await runDisposable(dispose)
+          }, this._runner.getOuterStack)
+        } catch (reason) {
+          diagnostics.errors.push(reason)
+          recordCheckedDisposalError(this.context, reason)
+          this.ctx.logger.error(reason)
+        }
+      }))
+      this.store = undefined
+      this._updateState(() => {
+        if (this._runner.epoch === INACTIVE) {
+          this.inertia = undefined
+        } else {
+          this.inertia = this._reload()
+          return FiberState.LOADING
+        }
+      })
+    } finally {
+      active.delete(diagnostics)
+      if (active.size === 0) activeUnloadDiagnostics.delete(root)
+    }
   }
 
   async await() {

--- a/packages/core/tests/terminal-disposal.spec.ts
+++ b/packages/core/tests/terminal-disposal.spec.ts
@@ -1,0 +1,439 @@
+import { Context, CordisError, FiberState, type Fiber } from '../src'
+import { describe, expect, it } from 'vitest'
+
+describe('Cordis effect ownership', () => {
+  it('makes an effect visible to a reentrant owner restart and awaits setup plus cleanup', async () => {
+    const ctx = new Context()
+    const setupGate = Promise.withResolvers<undefined>()
+    const cleanupGate = Promise.withResolvers<undefined>()
+    const cleanupStarted = Promise.withResolvers<undefined>()
+    let restarted!: Promise<void>
+    let setupFinished = false
+    let cleanupFinished = false
+
+    ctx.effect(async () => {
+      restarted = ctx.fiber.restart()
+      await setupGate.promise
+      setupFinished = true
+      return async () => {
+        cleanupStarted.resolve(undefined)
+        await cleanupGate.promise
+        cleanupFinished = true
+      }
+    }, 'reentrant-restart')
+
+    let settled = false
+    void restarted.then(() => { settled = true })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    setupGate.resolve(undefined)
+    await cleanupStarted.promise
+    expect(setupFinished).toBe(true)
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    cleanupGate.resolve(undefined)
+    await restarted
+    expect(cleanupFinished).toBe(true)
+    expect(ctx.fiber.getEffects()).toEqual([])
+  })
+
+  it('rolls back collected cleanup and its owner-list entry when setup throws synchronously', () => {
+    const ctx = new Context()
+    let cleanups = 0
+
+    expect(() => ctx.effect(function* () {
+      yield () => { cleanups += 1 }
+      throw new Error('setup failed')
+    }, 'throwing-setup')).toThrow('setup failed')
+
+    expect(cleanups).toBe(1)
+    expect(ctx.fiber.getEffects()).toEqual([])
+  })
+
+  it('makes a reentrant owner restart await asynchronous rollback after synchronous setup failure', async () => {
+    const ctx = new Context()
+    const cleanupGate = Promise.withResolvers<undefined>()
+    const cleanupStarted = Promise.withResolvers<undefined>()
+    let restarted!: Promise<void>
+
+    expect(() => ctx.effect(function* () {
+      yield async () => {
+        cleanupStarted.resolve(undefined)
+        await cleanupGate.promise
+      }
+      restarted = ctx.fiber.restart()
+      throw new Error('setup failed after restart')
+    }, 'reentrant-throw')).toThrow('setup failed after restart')
+
+    await cleanupStarted.promise
+    let settled = false
+    void restarted.then(() => { settled = true })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    cleanupGate.resolve(undefined)
+    await restarted
+    expect(ctx.fiber.getEffects()).toEqual([])
+  })
+
+  it('keeps ordinary teardown synchronous and the public disposer single-shot', () => {
+    const ctx = new Context()
+    let cleanups = 0
+    const dispose = ctx.effect(() => () => { cleanups += 1 }, 'sync-effect')
+
+    expect(dispose()).toBeUndefined()
+    expect(cleanups).toBe(1)
+    expect(dispose()).toBeUndefined()
+    expect(cleanups).toBe(1)
+    expect(ctx.fiber.getEffects()).toEqual([])
+  })
+
+  it('keeps ordinary child disposal failure-containing but reports every nested failure from checked root disposal', async () => {
+    const ordinary = new Context()
+    const ordinaryErrors: unknown[] = []
+    ordinary.logger.error = ((error: unknown) => { ordinaryErrors.push(error) }) as typeof ordinary.logger.error
+    const ordinaryChild = await ordinary.plugin({
+      name: 'ordinary-rejection',
+      apply(inner) {
+        inner.effect(() => async () => { throw new Error('ordinary cleanup failed') })
+      },
+    })
+    await expect(ordinaryChild.dispose()).resolves.toBeUndefined()
+    expect(ordinaryErrors).toEqual([expect.objectContaining({ message: 'ordinary cleanup failed' })])
+
+    const checked = new Context()
+    const checkedErrors: unknown[] = []
+    checked.logger.error = ((error: unknown) => { checkedErrors.push(error) }) as typeof checked.logger.error
+    let successfulCleanup = false
+    await checked.plugin({
+      name: 'checked-rejections',
+      apply(inner) {
+        inner.effect(() => async () => { throw new Error('nested cleanup failed') })
+        inner.effect(() => () => { successfulCleanup = true })
+      },
+    })
+    checked.effect(() => async () => { throw new Error('root cleanup failed') })
+
+    const first = checked.fiber.disposeChecked()
+    expect(checked.fiber.disposeChecked()).toBe(first)
+    const failure = await first.catch((error: unknown) => error)
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ message: 'nested cleanup failed' }),
+      expect.objectContaining({ message: 'root cleanup failed' }),
+    ]))
+    expect(checkedErrors).toHaveLength(2)
+    expect(successfulCleanup).toBe(true)
+  })
+
+  it('closes root admission before returning and lets lifecycle observers join the checked task', async () => {
+    const ctx = new Context()
+    let joined: Promise<void> | undefined
+    ctx.on('internal/status', (fiber) => {
+      if (fiber !== ctx.fiber || fiber.state !== FiberState.UNLOADING) return
+      joined = fiber.disposeChecked()
+    })
+
+    const checked = ctx.fiber.disposeChecked()
+    expect(joined).toBe(checked)
+    expect(() => ctx.effect(() => () => {}, 'too-late-for-terminal-disposal')).toThrow(
+      expect.objectContaining({ code: 'INACTIVE_EFFECT' }),
+    )
+    await expect(checked).resolves.toBeUndefined()
+  })
+
+  it('runs every yielded cleanup in reverse order before reporting composite failures', async () => {
+    const ctx = new Context()
+    const logged: unknown[] = []
+    ctx.logger.error = ((error: unknown) => { logged.push(error) }) as typeof ctx.logger.error
+    const calls: string[] = []
+    ctx.effect(function* () {
+      yield () => { calls.push('must-run') }
+      yield () => {
+        calls.push('sync-failure')
+        throw new Error('second cleanup failed')
+      }
+      yield async () => {
+        calls.push('async-start')
+        await Promise.resolve()
+        calls.push('async-failure')
+        throw new Error('first cleanup failed')
+      }
+    }, 'composite-cleanup')
+
+    const failure = await ctx.fiber.disposeChecked().catch((error: unknown) => error)
+    expect(calls).toEqual(['async-start', 'async-failure', 'sync-failure', 'must-run'])
+    expect(failure).toBeInstanceOf(AggregateError)
+    const [composite] = (failure as AggregateError).errors as unknown[]
+    expect(composite).toBeInstanceOf(AggregateError)
+    expect(composite).toMatchObject({
+      message: 'Cordis composite effect disposal failed',
+      errors: [
+        expect.objectContaining({ message: 'first cleanup failed' }),
+        expect.objectContaining({ message: 'second cleanup failed' }),
+      ],
+    })
+    expect(logged).toEqual([composite])
+  })
+
+  it('imports failures from an active child unload that checked root disposal joins', async () => {
+    const ctx = new Context()
+    const hold = Promise.withResolvers<undefined>()
+    const holdStarted = Promise.withResolvers<undefined>()
+    const earlyLogged = Promise.withResolvers<undefined>()
+    const logged: unknown[] = []
+    ctx.logger.error = ((error: unknown) => {
+      logged.push(error)
+      if (error instanceof Error && error.message === 'early child cleanup failed') {
+        earlyLogged.resolve(undefined)
+      }
+    }) as typeof ctx.logger.error
+    const child = await ctx.plugin({
+      name: 'overlapping-unload',
+      apply(inner) {
+        inner.effect(() => async () => {
+          holdStarted.resolve(undefined)
+          await hold.promise
+        }, 'held-cleanup')
+        inner.effect(() => async () => {
+          throw new Error('early child cleanup failed')
+        }, 'early-failure')
+      },
+    })
+
+    const childDisposal = child.dispose()
+    await Promise.all([holdStarted.promise, earlyLogged.promise])
+    const checked = ctx.fiber.disposeChecked()
+    let settled = false
+    void checked.then(
+      () => { settled = true },
+      () => { settled = true },
+    )
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    hold.resolve(undefined)
+    await expect(childDisposal).resolves.toBeUndefined()
+    const failure = await checked.catch((error: unknown) => error)
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual([
+      expect.objectContaining({ message: 'early child cleanup failed' }),
+    ])
+    expect(logged).toHaveLength(1)
+  })
+
+  it('does not carry a completed ordinary unload failure into later checked disposal', async () => {
+    const ctx = new Context()
+    const logged: unknown[] = []
+    ctx.logger.error = ((error: unknown) => { logged.push(error) }) as typeof ctx.logger.error
+    const child = await ctx.plugin({
+      name: 'completed-unload',
+      apply(inner) {
+        inner.effect(() => async () => { throw new Error('completed cleanup failed') })
+      },
+    })
+
+    await expect(child.dispose()).resolves.toBeUndefined()
+    expect(logged).toEqual([expect.objectContaining({ message: 'completed cleanup failed' })])
+    await expect(ctx.fiber.disposeChecked()).resolves.toBeUndefined()
+  })
+
+  it('rejects checked disposal on a non-root fiber', async () => {
+    const ctx = new Context()
+    const child = await ctx.plugin({ name: 'not-root', apply() {} })
+    expect(() => child.disposeChecked()).toThrow('only supported on the root fiber')
+    await ctx.fiber.dispose()
+  })
+
+  it('rejects cleanup-time registration while a restart is unloading', async () => {
+    const ctx = new Context()
+    let registrationError: unknown
+
+    ctx.effect(() => () => {
+      try {
+        ctx.effect(() => () => {}, 'too-late')
+      } catch (error) {
+        registrationError = error
+      }
+    }, 'restart-cleanup')
+
+    await ctx.fiber.restart()
+    expect(registrationError).toBeInstanceOf(CordisError)
+    expect((registrationError as CordisError).code).toBe('INACTIVE_EFFECT')
+    expect(ctx.fiber.state).toBe(FiberState.ACTIVE)
+    expect(ctx.fiber.getEffects()).toEqual([])
+  })
+
+  it('keeps effect registration legal while child fibers are PENDING and LOADING', async () => {
+    const ctx = new Context()
+    let pendingCleanup = false
+    let loadingCleanup = false
+
+    ctx.on('internal/plugin', (fiber) => {
+      if (fiber.name !== 'state-probe' || fiber.uid === null) return
+      expect(fiber.state).toBe(FiberState.PENDING)
+      fiber.ctx.effect(() => () => { pendingCleanup = true }, 'pending-effect')
+    })
+
+    const fiber = await ctx.plugin({
+      name: 'state-probe',
+      apply(inner) {
+        expect(inner.fiber.state).toBe(FiberState.LOADING)
+        inner.effect(() => () => { loadingCleanup = true }, 'loading-effect')
+      },
+    })
+    await fiber.dispose()
+
+    expect(pendingCleanup).toBe(true)
+    expect(loadingCleanup).toBe(true)
+  })
+
+  it('resolves dependencies that internal/plugin adds before child activation', async () => {
+    const ctx = new Context()
+    ctx.provide('late-inject', {})
+    let applyCalls = 0
+
+    ctx.on('internal/plugin', (fiber) => {
+      if (fiber.name !== 'loader-shaped' || fiber.uid === null) return
+      fiber.inject['late-inject'] = {}
+    })
+
+    const fiber = await ctx.plugin({
+      name: 'loader-shaped',
+      apply() {
+        applyCalls += 1
+      },
+    })
+
+    expect(applyCalls).toBe(1)
+    expect(fiber.state).toBe(FiberState.ACTIVE)
+  })
+})
+
+describe('Cordis child publication ownership', () => {
+  it('rolls back parent and runtime ownership when internal/plugin publication throws', () => {
+    const ctx = new Context()
+    const plugin = { name: 'publication-failure', apply() {} }
+    ctx.on('internal/plugin', (fiber) => {
+      if (fiber.name === plugin.name) throw new Error('publication failed')
+    })
+
+    expect(() => ctx.plugin(plugin)).toThrow('publication failed')
+    expect(ctx.registry.has(plugin)).toBe(false)
+  })
+
+  it('contains teardown notification failures so ownership cleanup and peers complete', async () => {
+    const ctx = new Context()
+    const errors: unknown[] = []
+    ctx.logger.error = ((error: unknown) => { errors.push(error) }) as typeof ctx.logger.error
+    const observed: string[] = []
+    ctx.on('internal/plugin', (fiber) => {
+      if (fiber.name === 'contained-teardown' && fiber.uid === null) {
+        throw new Error('broken teardown observer')
+      }
+    })
+    ctx.on('internal/plugin', (fiber) => {
+      if (fiber.name === 'contained-teardown' && fiber.uid === null) observed.push('disposed')
+    })
+    const child = await ctx.plugin({ name: 'contained-teardown', apply() {} })
+
+    await expect(child.dispose()).resolves.toBeUndefined()
+    expect(observed).toEqual(['disposed'])
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toEqual(expect.objectContaining({ message: 'broken teardown observer' }))
+    expect(child.uid).toBeNull()
+  })
+
+  it('makes a LOADING parent join child cleanup started before its unload snapshot', async () => {
+    const ctx = new Context()
+    const cleanupGate = Promise.withResolvers<undefined>()
+    const cleanupStarted = Promise.withResolvers<undefined>()
+    let ownerFiber!: Fiber
+    let ownerDisposal!: Promise<void>
+    let childDisposal!: Promise<void>
+    let childFiber!: Fiber
+
+    ctx.on('internal/plugin', (fiber) => {
+      if (fiber.name !== 'loading-child' || fiber.uid === null) return
+      childFiber = fiber
+      fiber.ctx.effect(() => async () => {
+        cleanupStarted.resolve(undefined)
+        await cleanupGate.promise
+      }, 'loading-child-cleanup')
+      ownerDisposal = ownerFiber.dispose()
+      childDisposal = Promise.resolve(fiber.dispose())
+    })
+
+    const ownerMount = ctx.plugin({
+      name: 'loading-owner',
+      apply(inner) {
+        ownerFiber = inner.fiber
+        inner.plugin({ name: 'loading-child', apply() {} })
+      },
+    })
+
+    await cleanupStarted.promise
+    let ownerSettled = false
+    void ownerDisposal.then(() => { ownerSettled = true })
+    await Promise.resolve()
+    expect(ownerSettled).toBe(false)
+
+    cleanupGate.resolve(undefined)
+    await Promise.all([ownerDisposal, childDisposal, ownerMount])
+    expect(childFiber.uid).toBeNull()
+    expect(ownerFiber.uid).toBeNull()
+  })
+
+  it('lets parent disposal during internal/plugin await the unpublished child to quiescence', async () => {
+    const ctx = new Context()
+    let ownerCtx!: Context
+    const owner = await ctx.plugin({
+      name: 'owner',
+      apply(inner) {
+        ownerCtx = inner
+      },
+    })
+
+    const cleanupGate = Promise.withResolvers<undefined>()
+    const cleanupStarted = Promise.withResolvers<undefined>()
+    let cleanupFinished = false
+    let childApplyCalls = 0
+    let parentDisposal!: Promise<void>
+
+    ctx.on('internal/plugin', (fiber) => {
+      if (fiber.name !== 'child' || fiber.uid === null) return
+      expect(fiber.state).toBe(FiberState.PENDING)
+      fiber.ctx.effect(() => async () => {
+        cleanupStarted.resolve(undefined)
+        await cleanupGate.promise
+        cleanupFinished = true
+      }, 'pending-child-cleanup')
+    })
+    ctx.on('internal/plugin', (fiber) => {
+      if (fiber.name !== 'child' || fiber.uid === null) return
+      parentDisposal = owner.dispose()
+    })
+
+    const child = ownerCtx.plugin({
+      name: 'child',
+      apply() {
+        childApplyCalls += 1
+      },
+    })
+
+    await cleanupStarted.promise
+    let settled = false
+    void parentDisposal.then(() => { settled = true })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    cleanupGate.resolve(undefined)
+    await parentDisposal
+    expect(cleanupFinished).toBe(true)
+    expect(childApplyCalls).toBe(0)
+    expect(child.uid).toBeNull()
+    expect(child.state).toBe(FiberState.DISPOSED)
+  })
+})


### PR DESCRIPTION
## Summary

- add root-only `Fiber.disposeChecked()` for terminal owners that need synchronous admission closure, full-tree quiescence, and one aggregate failure after all cleanup is attempted
- keep ordinary `dispose()` failure-containing for plugin/HMR unloads while letting a checked root audit join failures from unload work that is still active
- make composite/generator effect teardown run every collected cleanup sequentially in reverse order before reporting failures
- harden effect setup, rollback, child publication, reentrant disposal, and observer cleanup so ownership is established before lifecycle callbacks can race it
- add 17 focused regressions for checked disposal, active-unload overlap, all-attempt cleanup, concurrent/reentrant joins, admission closure, and prerequisite ownership races

## Why

Ordinary Cordis disposal intentionally logs and contains cleanup failures, which is appropriate for plugin reload. A process-level terminal owner has a different contract: it must reject new effects immediately, join cleanup already running anywhere in the root tree, attempt every independent cleanup, and learn whether the terminal transaction failed only after the tree is quiescent.

This cannot be reconstructed outside Cordis because ordinary disposal hides nested failures and a child unload may already have observed an error before the root audit starts.

## Compatibility

Existing `dispose()` behavior remains failure-containing. `disposeChecked()` is root-only and rejects with `AggregateError('Cordis root disposal failed')` after quiescence. Completed historical plugin-unload failures do not poison a later checked disposal.

## Validation

- `npx -y corepack@latest yarn test core` — 12 files, 78 tests passed
- `npx -y corepack@latest yarn yakumo tsc core` — passed
- `npx -y corepack@latest yarn eslint packages/core/src/fiber.ts` — passed
- `git diff --check origin/main...HEAD` — passed

Node emitted only the existing `DEP0205 module.register()` deprecation warning from the upstream dependency path.
