### PR TITLE
fix(core): track direct service callers

### DIFF
--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -220,7 +220,8 @@ export class LoggerService {
 
   [symbols.invoke](name?: string): Logger {
     const config = this._resolveConfig()
-    const fiber = ((this.ctx as any)[symbols.shadow] ?? this.ctx).fiber
+    const caller = (this as any)[symbols.caller] as Context | undefined
+    const fiber = (caller ?? this.ctx).fiber
     name ??= config.name
     name ??= hyphenate(fiber.name)
     return new Logger({

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -47,6 +47,7 @@ export interface Tracker {
 export const symbols = {
   // internal symbols
   shadow: Symbol.for('cordis.shadow'),
+  caller: Symbol.for('cordis.caller'),
   receiver: Symbol.for('cordis.receiver'),
   original: Symbol.for('cordis.original'),
   metadata: Symbol.for('cordis.metadata'),
@@ -154,16 +155,14 @@ function createShadowMethod(ctx: Context, value: any, outer: any, shadow: {}) {
 }
 
 function createTraceable(ctx: Context, value: any, tracker: Tracker) {
-  // noShadow services are identity-aware (e.g. logger uses the origin fiber to
-  // derive its name): keep the shadow ctx so they can read [symbols.shadow]
-  // and resolve the origin. Non-noShadow services strip — their side effects
-  // bind to caller, not origin.
-  if (ctx[symbols.shadow] && !tracker.noShadow) {
+  const caller = (ctx[symbols.shadow] as Context | undefined) ?? ctx
+  if (ctx[symbols.shadow]) {
     ctx = Object.getPrototypeOf(ctx)
   }
   const proxy = new Proxy(value, {
     get: (target, prop, receiver) => {
       if (prop === symbols.original) return target
+      if (prop === symbols.caller) return caller
       if (prop === tracker.property) return ctx
       if (typeof prop === 'symbol') {
         return Reflect.get(target, prop, receiver)
@@ -191,6 +190,7 @@ function createTraceable(ctx: Context, value: any, tracker: Tracker) {
     },
     set: (target, prop, value, receiver) => {
       if (prop === symbols.original) return false
+      if (prop === symbols.caller) return false
       if (prop === tracker.property) return false
       if (typeof prop === 'symbol') {
         return Reflect.set(target, prop, value, receiver)

--- a/packages/core/tests/logger.spec.ts
+++ b/packages/core/tests/logger.spec.ts
@@ -69,6 +69,37 @@ describe('Logger', () => {
     expect(captured.map(m => m.name)).not.toContain('foo:driver')
   })
 
+  it('uses the innermost service name and restores the outer service', async () => {
+    const { ctx, captured } = setup()
+
+    class BarService extends Service {
+      static name = 'bar:driver'
+      constructor(ctx: Context) { super(ctx, 'bar') }
+      action() {
+        this.ctx.logger.debug('from bar')
+      }
+    }
+
+    class FooService extends Service {
+      static name = 'foo:driver'
+      static inject = ['bar']
+      constructor(ctx: Context) { super(ctx, 'foo') }
+      action() {
+        this.ctx.bar.action()
+        this.ctx.logger.debug('from foo')
+      }
+    }
+
+    await ctx.plugin(BarService)
+    await ctx.plugin(FooService)
+    await ctx.inject(['foo'], ctx => ctx.foo.action())
+
+    expect(captured.map(m => [m.name, m.args[0]])).toEqual([
+      ['bar:driver', 'from bar'],
+      ['foo:driver', 'from foo'],
+    ])
+  })
+
   it('uses service name when called from inside [Service.init] (unchanged behaviour)', async () => {
     const { ctx, captured } = setup()
 

--- a/packages/core/tests/shadow.spec.ts
+++ b/packages/core/tests/shadow.spec.ts
@@ -1,0 +1,176 @@
+import { Context, Service, symbols } from '../src'
+import { describe, expect, it } from 'vitest'
+
+describe('Traceable caller', () => {
+  it('keeps caller metadata separate from the service shadow', async () => {
+    let innerOrigin: Context
+    let outerOrigin: Context
+
+    class Inner extends Service {
+      constructor(ctx: Context) {
+        super(ctx, 'inner')
+        innerOrigin = ctx
+      }
+
+      inspect() {
+        return {
+          caller: (this as any)[symbols.caller] as Context,
+          shadow: this.ctx[symbols.shadow] as Context,
+        }
+      }
+    }
+
+    class Outer extends Service {
+      static inject = ['inner']
+
+      constructor(ctx: Context) {
+        super(ctx, 'outer')
+        outerOrigin = ctx
+      }
+
+      inspect() {
+        const result = (this.ctx['inner'] as Inner).inspect()
+        return {
+          ...result,
+          outerShadow: this.ctx[symbols.shadow] as Context,
+        }
+      }
+    }
+
+    const root = new Context()
+    await root.plugin(Inner)
+    await root.plugin(Outer)
+
+    let result!: ReturnType<Outer['inspect']>
+    await root.inject(['outer'], (ctx) => {
+      result = ctx['outer'].inspect()
+    })
+
+    expect(result.caller).toBe(outerOrigin!)
+    expect(result.shadow).toBe(innerOrigin!)
+    expect(result.outerShadow).toBe(outerOrigin!)
+  })
+
+  it('exposes the caller without preserving shadow for noShadow services', async () => {
+    let outerOrigin: Context
+
+    class Probe {
+      [Service.tracker] = {
+        property: 'ctx',
+        noShadow: true,
+      }
+
+      constructor(public ctx: Context) {}
+
+      inspect() {
+        return {
+          caller: (this as any)[symbols.caller] as Context,
+          shadow: this.ctx[symbols.shadow] as Context | undefined,
+        }
+      }
+    }
+
+    class Outer extends Service {
+      static inject = ['probe']
+
+      constructor(ctx: Context) {
+        super(ctx, 'outer')
+        outerOrigin = ctx
+      }
+
+      inspect() {
+        return (this.ctx['probe'] as Probe).inspect()
+      }
+    }
+
+    const root = new Context()
+    root.provide('probe', new Probe(root))
+    await root.plugin(Outer)
+
+    let result!: ReturnType<Outer['inspect']>
+    await root.inject(['outer'], (ctx) => {
+      result = ctx['outer'].inspect()
+    })
+
+    expect(result.caller).toBe(outerOrigin!)
+    expect(result.shadow).toBeUndefined()
+  })
+
+  it('exposes the caller to callable services', async () => {
+    let outerOrigin: Context
+
+    interface Callable {
+      (): Context
+    }
+
+    class Callable extends Service {
+      constructor(ctx: Context) {
+        super(ctx, 'callable')
+      }
+
+      protected [Service.invoke]() {
+        return (this as any)[symbols.caller] as Context
+      }
+    }
+
+    class Outer extends Service {
+      static inject = ['callable']
+
+      constructor(ctx: Context) {
+        super(ctx, 'outer')
+        outerOrigin = ctx
+      }
+
+      call() {
+        return (this.ctx['callable'] as Callable)()
+      }
+    }
+
+    const root = new Context()
+    await root.plugin(Callable)
+    await root.plugin(Outer)
+
+    let caller!: Context
+    await root.inject(['outer'], (ctx) => {
+      caller = ctx['outer'].call()
+    })
+
+    expect(caller).toBe(outerOrigin!)
+  })
+
+  it('strips service shadow before creating plugins', async () => {
+    class Loader extends Service {
+      constructor(ctx: Context) {
+        super(ctx, 'loader')
+      }
+
+      load(plugin: any) {
+        return this.ctx.plugin(plugin)
+      }
+    }
+
+    class Server extends Service {
+      constructor(ctx: Context) {
+        super(ctx, 'server')
+      }
+    }
+
+    let injected = false
+    function Consumer(ctx: Context) {
+      return ctx.inject(['server'], ({ server }: any) => {
+        injected = server instanceof Server
+      })
+    }
+
+    const root = new Context()
+    await root.plugin(Loader)
+    await root.inject(['loader'], async (ctx) => {
+      const loader = ctx['loader'] as any
+      await loader.load(Server)
+      await loader.load(Consumer)
+    })
+
+    expect(injected).toBe(true)
+    expect(root.logger.buffer.filter(message => message.type === 'error')).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Logger 在 dd8bf6e838c8fc8fd661c09a6507d54e9fc46161 使用 shadow 相关语义来模拟获取 caller name ，其依赖于 Logger 不再调用其他服务的事实（否则 shadow 的语义就会被破坏），而这是不平凡的。

同时引入的改动使 Registry 等 noShadow internal service 语义改变而将自身泄漏到下游。

考虑调用 C -> A.foo() -> B.bar()
|Context[shadow]|rc5|rc6|
|-|-|-|
|service|C[A] -> C[B]|C[A] -> C[B]|
|noShadow|C[A] -> C[∅]|C[A] -> C[A]|
|Logger|C[A] -> C[B]|C[A] -> C[A]|

这里实际上混合了两种语义（即无法通过 shadow 本身表达）。

因此重新引入 caller 作为泛用方案。