### PR TITLE
fix(core): logger exporter dispose

### DIFF
--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -190,8 +190,11 @@ export class LoggerService {
       colors: 3,
       export: (message) => {
         self.buffer.push(message)
-        if (self.buffer.length > self.bufferSize) {
-          self.buffer = self.buffer.slice(-self.bufferSize)
+        const overflow = self.buffer.length - self.bufferSize
+        if (overflow === 1) {
+          self.buffer.shift()
+        } else if (overflow > 1) {
+          self.buffer.splice(0, overflow)
         }
       },
     })
@@ -201,8 +204,9 @@ export class LoggerService {
 
   exporter(exporter: Exporter) {
     return this.ctx.effect(() => {
-      this.exporters.set(++this._snExporter, exporter)
-      return () => this.exporters.delete(this._snExporter)
+      const id = ++this._snExporter
+      this.exporters.set(id, exporter)
+      return () => this.exporters.delete(id)
     }, 'ctx.logger.exporter()')
   }
 

--- a/packages/core/tests/logger.spec.ts
+++ b/packages/core/tests/logger.spec.ts
@@ -15,6 +15,43 @@ function setup() {
 }
 
 describe('Logger', () => {
+  it('keeps the bounded buffer in place and chronological', () => {
+    const ctx = new Context()
+    const buffer = ctx.logger.buffer
+    ctx.logger.bufferSize = 2
+    ctx.logger.info('one')
+    ctx.logger.info('two')
+    ctx.logger.info('three')
+    expect(ctx.logger.buffer).toBe(buffer)
+    expect(buffer.map(message => message.args[0])).toEqual(['two', 'three'])
+
+    ctx.logger.bufferSize = 1
+    ctx.logger.info('four')
+    expect(buffer.map(message => message.args[0])).toEqual(['four'])
+
+    ctx.logger.bufferSize = 0
+    ctx.logger.info('five')
+    expect(buffer).toEqual([])
+  })
+
+  it('disposes the exporter that registered the disposer', () => {
+    const ctx = new Context()
+    ctx.logger.exporters.clear()
+    const first: Message[] = []
+    const second: Message[] = []
+    const disposeFirst = ctx.logger.exporter({ export: message => first.push(message) })
+    const disposeSecond = ctx.logger.exporter({ export: message => second.push(message) })
+
+    disposeFirst()
+    ctx.logger.info('test')
+    expect(first).toEqual([])
+    expect(second).toHaveLength(1)
+
+    disposeSecond()
+    ctx.logger.info('test')
+    expect(second).toHaveLength(1)
+  })
+
   it('uses fiber name when called from outside any service', () => {
     const { ctx, captured } = setup()
     ctx.logger.debug('hello')


### PR DESCRIPTION
perf(core): avoid logger buffer reallocations
