### PR TITLE
feat(core): make effect disposal and Fiber lifecycle reentrant-safe

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -161,7 +161,7 @@ export interface Events {
   'internal/plugin'(fiber: Fiber): void
   'internal/status'(fiber: Fiber, oldValue: FiberState): void
   'internal/service'(this: Context, name: string, value: any): void
-  'internal/update'(this: Fiber, config: any, noSave: boolean, next: () => void): void
+  'internal/update'(this: Fiber, config: any, noSave: boolean, next: () => void | Promise<void>): void | Promise<void>
   'internal/get'(ctx: Context, name: string, error: Error, next: () => any): any
   'internal/set'(ctx: Context, name: string, value: any, error: Error, next: () => boolean): boolean
   'internal/listener'(this: Context, name: string, listener: any, prepend: boolean): void

--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -1,7 +1,7 @@
 import { Awaitable, defineProperty, Dict, isNullable } from 'cosmokit'
 import { Context } from './context'
 import { Plugin } from './registry'
-import { buildOuterStack, composeError, DisposableList, getTraceable, isConstructor, isObject, symbols } from './utils'
+import { buildOuterStack, composeError, DisposableList, getTraceable, isConstructor, isObject, isPromiseLike, symbols } from './utils'
 import { Impl } from './reflect'
 import { StandardSchemaV1 } from '@standard-schema/spec'
 
@@ -75,6 +75,57 @@ interface EffectRunner<T> {
   getOuterStack: () => string[]
 }
 
+interface DesiredSnapshot {
+  loadable: boolean
+  config: any
+  implementations: Impl[]
+}
+
+// Loadable epochs are opaque generation tokens. Desired-state equality is
+// tracked separately so an A -> B -> A transition cannot revive work from A.
+type FiberEpoch = object | typeof INACTIVE
+
+function combineErrors(errors: unknown[], primary?: unknown) {
+  // Do not flatten user AggregateErrors: one cleanup callback owns one error.
+  // We only inspect nesting to avoid inserting the same primary error twice.
+  const contains = (error: unknown): boolean => {
+    if (error === primary) return true
+    return error instanceof AggregateError && error.errors.some(contains)
+  }
+  const combined = primary !== undefined && !errors.some(contains) ? [primary, ...errors] : errors
+  if (!combined.length) return
+  if (combined.length === 1) return combined[0]
+  return new AggregateError(combined, 'multiple lifecycle errors', primary === undefined ? undefined : { cause: primary })
+}
+
+function dispatchFiberDisposal(context: Context, fiber: Fiber) {
+  // Fiber disposal notification is contained per observer. Structural
+  // cleanup must continue even if dispatch, a synchronous observer, or an
+  // async observer fails; the caller later combines these outcomes with
+  // cleanup failures.
+  const args: any[] = ['internal/plugin', fiber]
+  let callbacks: Function[]
+  try {
+    callbacks = context.events.dispatch('emit', args)
+  } catch (error) {
+    return [Promise.resolve({ status: 'rejected' as const, reason: error })]
+  }
+
+  const tasks: Promise<{ status: 'fulfilled' } | { status: 'rejected', reason: unknown }>[] = []
+  for (const callback of callbacks) {
+    try {
+      const result = callback(...args)
+      tasks.push(Promise.resolve(result).then(
+        () => ({ status: 'fulfilled' as const }),
+        reason => ({ status: 'rejected' as const, reason }),
+      ))
+    } catch (error) {
+      tasks.push(Promise.resolve({ status: 'rejected' as const, reason: error }))
+    }
+  }
+  return tasks
+}
+
 export const enum FiberState {
   PENDING,
   LOADING,
@@ -98,7 +149,179 @@ export namespace CordisError {
   } as const
 }
 
-const INACTIVE = '__INACTIVE__'
+const INACTIVE = Symbol.for('cordis.inactive')
+
+type EffectExecutionState = 'running' | 'pending' | 'fulfilled' | 'rejected'
+
+interface ExecutionGate {
+  promise: Promise<void>
+  resolve: () => void
+  reject: (reason: unknown) => void
+}
+
+class EffectRecord {
+  readonly meta: EffectMeta
+  readonly runner: EffectRunner<boolean>
+  readonly dispose: Disposable<Promise<void>>
+  readonly wrapper: AsyncDisposable<Promise<void>>
+
+  private cleanups: Disposable[] = []
+  private executionState: EffectExecutionState = 'running'
+  private executionError: unknown
+  private executionTask?: Promise<void>
+  private executionGate?: ExecutionGate
+  private disposalTask?: Promise<void>
+  private removeWrapper: () => boolean
+
+  constructor(private owner: Fiber, execute: () => Effect, label: string) {
+    this.meta = { label, children: [] }
+    this.runner = {
+      execute,
+      epoch: true,
+      collect: dispose => this.collect(dispose),
+      getOuterStack: buildOuterStack(),
+    }
+    this.dispose = () => this.startDisposal()
+    this.wrapper = defineProperty(() => this.startDisposal(), symbols.effect, this.meta) as AsyncDisposable<Promise<void>>
+    this.wrapper.then = (onFulfilled, onRejected) => {
+      return this.waitForExecution().then(() => this.dispose).then(onFulfilled, onRejected)
+    }
+    // Establish ownership before execution can enter user code. A reentrant
+    // owner restart can now capture this wrapper in its unload snapshot.
+    this.removeWrapper = owner._disposables.push(this.wrapper)
+  }
+
+  private collect(dispose: Disposable) {
+    this.cleanups.push(dispose)
+    this.owner._disposables.delete(dispose)
+    if (dispose[symbols.effect]) this.meta.children.push(dispose[symbols.effect])
+  }
+
+  private waitForExecution() {
+    if (this.executionState === 'fulfilled') return Promise.resolve()
+    if (this.executionState === 'rejected') return Promise.reject(this.executionError)
+    if (this.executionTask) return this.executionTask
+    if (!this.executionGate) {
+      // Synchronous execution normally allocates no promise. The gate is
+      // created only when disposal actually reenters before execution returns.
+      let resolve!: () => void
+      let reject!: (reason: unknown) => void
+      const promise = new Promise<void>((res, rej) => {
+        resolve = res
+        reject = rej
+      })
+      promise.catch(() => {})
+      this.executionGate = { promise, resolve, reject }
+    }
+    return this.executionGate.promise
+  }
+
+  settleExecution(task: void | Promise<void>) {
+    if (!isPromiseLike(task)) {
+      this.executionState = 'fulfilled'
+      this.executionGate?.resolve()
+      return
+    }
+    this.executionState = 'pending'
+    // Keep one execution task for both the thenable effect API and disposal
+    // that starts while asynchronous execution is pending.
+    this.executionTask = Promise.resolve(task).then(() => {
+      this.executionState = 'fulfilled'
+      this.executionGate?.resolve()
+    }, (reason) => {
+      this.failExecution(reason, true)
+      throw reason
+    })
+    this.executionTask.catch(() => {})
+  }
+
+  failExecution(reason: unknown, report = false) {
+    this.executionState = 'rejected'
+    this.executionError = reason
+    this.executionGate?.reject(reason)
+    if (report) this.owner.ctx.logger.error(reason)
+    // Execution failure is synchronous to the caller, while rollback remains
+    // owner-visible and may finish asynchronously.
+    this.startDisposal(reason).catch((error) => {
+      if (error !== reason) this.owner.ctx.logger.error(error)
+    })
+  }
+
+  private runCleanups() {
+    const errors: unknown[] = []
+    const pending = this.cleanups.splice(0).reverse()
+    let index = 0
+
+    const next = (): void | Promise<void> => {
+      while (index < pending.length) {
+        const dispose = pending[index++]
+        try {
+          const result = dispose()
+          if (isPromiseLike(result)) {
+            // Preserve strict LIFO ordering across async cleanup. Rejections
+            // are recorded and do not veto the remaining cleanup callbacks.
+            return Promise.resolve(result).then(next, (error) => {
+              errors.push(error)
+              return next()
+            })
+          }
+        } catch (error) {
+          errors.push(error)
+        }
+      }
+    }
+
+    const result = next()
+    return isPromiseLike(result) ? Promise.resolve(result).then(() => errors) : errors
+  }
+
+  private finishDisposal(primary?: unknown) {
+    const finalize = (errors: unknown[]) => {
+      const error = combineErrors(errors, primary)
+      return error ? Promise.reject<void>(error) : Promise.resolve()
+    }
+    const result = this.runCleanups()
+    if (isPromiseLike(result)) return { task: Promise.resolve(result).then(finalize), synchronous: false }
+    return { task: finalize(result), synchronous: true }
+  }
+
+  private startDisposal(primary?: unknown) {
+    // Public callers and structural owners always join the first task; cleanup
+    // itself is exactly-once.
+    if (this.disposalTask) return this.disposalTask
+    this.runner.epoch = false
+
+    let task: Promise<void>
+    let synchronous = false
+    if (this.executionState === 'fulfilled') {
+      ;({ task, synchronous } = this.finishDisposal(primary))
+    } else if (this.executionState === 'rejected') {
+      ;({ task, synchronous } = this.finishDisposal(primary ?? this.executionError))
+    } else {
+      task = this.waitForExecution().then(
+        () => this.finishDisposal(primary).task,
+        error => this.finishDisposal(primary ?? error).task,
+      )
+    }
+
+    if (synchronous && !this.owner.inertia) {
+      // Outside an owner transition, fully synchronous cleanup can retire the
+      // wrapper immediately. During unload it stays joinable until settlement.
+      this.removeWrapper()
+      this.disposalTask = task
+    } else {
+      this.disposalTask = task.then(
+        () => { this.removeWrapper() },
+        (error) => {
+          this.removeWrapper()
+          throw error
+        },
+      )
+    }
+    this.disposalTask.catch(() => {})
+    return this.disposalTask
+  }
+}
 
 export class Fiber {
   public uid: number | null
@@ -116,8 +339,9 @@ export class Fiber {
   protected context: Context
 
   private _error: any
-  private _runner: EffectRunner<string>
+  private _runner: EffectRunner<FiberEpoch>
   private _store: Dict<Impl> = Object.create(null)
+  private _desired?: DesiredSnapshot
 
   constructor(
     public parent: Context,
@@ -161,24 +385,23 @@ export class Fiber {
         collect,
       }
 
-      this.context.emit('internal/plugin', this)
-
-      for (const name of Object.keys(this.inject)) {
-        this._checkImpl(name)
-      }
-
+      let shouldRefresh = false
+      // A child is represented as an effect owned by its parent. This creates
+      // child.dispose and runtime ownership before publication runs listeners.
       this.dispose = parent.fiber.effect(() => {
         const remove = runtime.fibers.push(this)
         try {
           this.config = resolveConfig(runtime, config)
-          this._refresh()
+          shouldRefresh = true
         } catch (error) {
           this.ctx.logger.error(error)
           this._error = error
         }
         return async () => {
           this.uid = null
-          this.context.emit('internal/plugin', this)
+          // Start observers before structural cleanup, but await both together
+          // so neither can starve the other and all failures remain visible.
+          const notificationTasks = dispatchFiberDisposal(this.context, this)
           if (this.ctx.registry.has(runtime.callback)) {
             remove()
             if (!runtime.fibers.length) {
@@ -186,24 +409,54 @@ export class Fiber {
             }
           }
           this._setEpoch(INACTIVE)
-          // `this.inertia` itself should never reject — both `_reload` and
-          // `_unload` swallow their own work errors via `ctx.logger.error`.
-          // If it *does* reject, the only remaining cause is the logger
-          // itself failing, which we can't recover from in this exact spot
-          // (calling the logger again is what just failed). Let the
-          // rejection propagate; process-level crash is the honest outcome.
-          while (this.inertia) {
-            await this.inertia
+          if (!this.inertia) {
+            this._updateState(() => {
+              this.inertia = this._observeLifecycleTask(this._unload())
+              return FiberState.UNLOADING
+            })
           }
+          const lifecycleTask = (async () => {
+            while (this.inertia) await this.inertia
+          })()
+          const [notifications, lifecycle] = await Promise.all([
+            Promise.all(notificationTasks),
+            lifecycleTask.then(() => ({ status: 'fulfilled' as const }), reason => ({ status: 'rejected' as const, reason })),
+          ])
+          const errors = notifications
+            .filter((result): result is { status: 'rejected', reason: unknown } => result.status === 'rejected')
+            .map(result => result.reason)
+          if (lifecycle.status === 'rejected') errors.push(lifecycle.reason)
+          const error = combineErrors(errors)
+          if (error) throw error
         }
       }, 'ctx.plugin()')
+
+      try {
+        // Publication is fail-fast, but ownership already exists, allowing the
+        // catch path to synchronously terminalize and begin rollback.
+        this.context.emit('internal/plugin', this)
+      } catch (error) {
+        this.dispose().catch(reason => this.ctx.logger.error(reason))
+        throw error
+      }
+
+      if (this.uid !== null && parent.fiber.state !== FiberState.UNLOADING) {
+        for (const name of Object.keys(this.inject)) {
+          this._checkImpl(name)
+        }
+        if (shouldRefresh) {
+          this._refresh()
+        } else if (this._error) {
+          this._updateState(() => FiberState.FAILED)
+        }
+      }
     } else {
       this.uid = 0
       this.ctx = this.context = parent
       this.state = FiberState.ACTIVE
       this.store = Object.create(null)
       this._runner = {
-        epoch: '',
+        epoch: {},
         getOuterStack,
         execute: () => {},
         collect,
@@ -275,68 +528,21 @@ export class Fiber {
   effect(execute: () => SyncEffect, label?: string): Disposable<Promise<void>>
   effect(execute: () => Effect, label?: string): AsyncDisposable<Promise<void>>
   effect(execute: () => Effect, label = 'anonymous'): any {
-    this.assertActive()
-
-    const disposables: Disposable[] = []
-    const dispose = () => {
-      let task!: void | Promise<void>
-      for (const dispose of disposables.splice(0).reverse()) {
-        if (task) {
-          task = task.then(dispose)
-        } else {
-          const result = dispose()
-          if (isObject(result) && 'then' in result) {
-            task = result as any
-          }
-        }
-      }
-      return task
+    const fiber = this.ctx.fiber
+    fiber.assertActive()
+    if (fiber.state === FiberState.UNLOADING) {
+      throw new CordisError('INACTIVE_EFFECT')
     }
-
-    const meta: EffectMeta = { label, children: [] }
-    const runner: EffectRunner<boolean> = {
-      execute,
-      epoch: true,
-      collect: (dispose) => {
-        disposables.push(dispose)
-        this._disposables.delete(dispose)
-        if (dispose[symbols.effect]) {
-          meta.children.push(dispose[symbols.effect])
-        }
-      },
-      getOuterStack: buildOuterStack(),
-    }
-
+    const record = new EffectRecord(fiber, execute, label)
     let task: void | Promise<void>
     try {
-      task = this._execute(runner)
+      task = fiber._execute(record.runner)
     } catch (reason) {
-      dispose()
+      record.failExecution(reason)
       throw reason
     }
-
-    // prevent unhandled rejection — both from `task` itself and from the
-    // disposer chain if it fails to settle cleanly.
-    task?.catch(dispose).catch((error) => this.ctx.logger.error(error))
-
-    const wrapper = defineProperty(() => {
-      if (!runner.epoch) return
-      runner.epoch = false
-      return task ? task.then(dispose) : dispose()
-    }, symbols.effect, meta) as AsyncDisposable
-
-    const disposeAsync = () => {
-      if (!runner.epoch) return
-      runner.epoch = false
-      return dispose()
-    }
-    wrapper.then = async (onFulfilled, onRejected) => {
-      return Promise.resolve(task)
-        .then(() => disposeAsync)
-        .then(onFulfilled, onRejected)
-    }
-    disposables.push(this._disposables.push(wrapper))
-    return wrapper
+    record.settleExecution(task)
+    return record.wrapper
   }
 
   getEffects() {
@@ -382,31 +588,56 @@ export class Fiber {
     this._store[name] = impl
   }
 
-  _refresh() {
-    let epoch: string | boolean = false
-    epoch = ''
+  private _observeLifecycleTask(task: Promise<void>) {
+    // Attach an observer so internally scheduled transitions never become
+    // process-level unhandled rejections. Return the original task unchanged;
+    // fiber.await() can still observe the same rejection.
+    task.catch(() => {})
+    return task
+  }
+
+  private _isSameDesired(snapshot: DesiredSnapshot) {
+    const current = this._desired
+    if (!current || current.loadable !== snapshot.loadable || current.config !== snapshot.config) return false
+    if (current.implementations.length !== snapshot.implementations.length) return false
+    return current.implementations.every((impl, index) => impl === snapshot.implementations[index])
+  }
+
+  _refresh(force = false) {
+    if (this.uid === null) return
+    const implementations: Impl[] = []
+    let loadable = true
     for (const name of Object.keys(this.inject)) {
       const impl = this._store[name]
       if (!impl) {
-        epoch = INACTIVE
+        loadable = false
         break
       }
-      epoch += ':' + impl.fiber.uid
+      implementations.push(impl)
     }
-    this._setEpoch(epoch)
+
+    const desired = { loadable, config: this.config, implementations }
+    // Equal notifications coalesce, while force (restart/config update) always
+    // allocates a fresh token even when the snapshot is structurally equal.
+    if (!force && this._isSameDesired(desired)) return
+    this._desired = desired
+    this._setEpoch(loadable ? {} : INACTIVE)
   }
 
-  private _setEpoch(epoch: string) {
+  private _setEpoch(epoch: FiberEpoch) {
     const oldEpoch = this._runner.epoch
     if (epoch === oldEpoch) return
     this._runner.epoch = epoch
+    if (epoch !== INACTIVE) this._error = undefined
+    // An in-flight transition owns the serialized pump. Updating the token is
+    // enough; it will read the latest target after execution/cleanup settles.
     if (this.inertia) return
     this._updateState(() => {
       if (epoch !== INACTIVE && oldEpoch === INACTIVE) {
-        this.inertia = this._reload()
+        this.inertia = this._observeLifecycleTask(this._reload())
         return FiberState.LOADING
       } else {
-        this.inertia = this._unload()
+        this.inertia = this._observeLifecycleTask(this._unload())
         return FiberState.UNLOADING
       }
     })
@@ -415,70 +646,102 @@ export class Fiber {
   private async _reload() {
     this.store = { ...this._store }
     const oldEpoch = this._runner.epoch
+    let executionError: unknown
     try {
+      // Give synchronous invalidation a checkpoint before plugin user code.
       await Promise.resolve()
-      await this._execute(this._runner)
+      if (this._runner.epoch === oldEpoch) {
+        await this._execute(this._runner)
+      }
     } catch (reason) {
-      // impl guarantees that the error is non-null (?)
       this.ctx.logger.error(reason)
-      this._error = reason
-      this._runner.epoch = INACTIVE
+      // A stale execution may be diagnosed, but it must not overwrite current
+      // generation's error or target token.
+      if (this._runner.epoch === oldEpoch) {
+        executionError = reason
+        this._runner.epoch = INACTIVE
+      }
     }
     this._updateState(() => {
+      if (executionError !== undefined) {
+        this.inertia = this._observeLifecycleTask(this._unload(executionError))
+        return FiberState.UNLOADING
+      }
       if (this._runner.epoch === oldEpoch) {
         this.inertia = undefined
       } else {
-        this.inertia = this._unload()
+        this.inertia = this._observeLifecycleTask(this._unload())
         return FiberState.UNLOADING
       }
     })
   }
 
-  private async _unload() {
-    await Promise.all(this._disposables.clear().map(async (dispose) => {
+  private async _unload(primary?: unknown) {
+    // Top-level effects may clean up concurrently. Promise.all preserves input
+    // order, giving deterministic error aggregation independent of settlement.
+    const outcomes = await Promise.all(this._disposables.clear().map(async (dispose) => {
       try {
         await composeError(async (info) => {
           await Promise.resolve()
           info.error = new Error()
           await dispose()
         }, this._runner.getOuterStack)
+        return { status: 'fulfilled' as const }
       } catch (reason) {
-        this.ctx.logger.error(reason)
+        return { status: 'rejected' as const, reason }
       }
     }))
+    const errors = outcomes
+      .filter((outcome): outcome is { status: 'rejected', reason: unknown } => outcome.status === 'rejected')
+      .map(outcome => outcome.reason)
+    const error = combineErrors(errors, primary)
+
     this.store = undefined
     this._updateState(() => {
-      if (this._runner.epoch === INACTIVE) {
+      // Terminal disposal always reaches DISPOSED. For non-terminal failures,
+      // stop the pump in FAILED rather than activating a replacement on top of
+      // resources whose cleanup may have failed.
+      if (this.uid === null) {
+        this.inertia = undefined
+      } else if (error) {
+        this._error = error
+        this._runner.epoch = INACTIVE
+        this.inertia = undefined
+      } else if (this._runner.epoch === INACTIVE) {
         this.inertia = undefined
       } else {
-        this.inertia = this._reload()
+        this.inertia = this._observeLifecycleTask(this._reload())
         return FiberState.LOADING
       }
     })
+    if (error) throw error
   }
 
   async await() {
-    while (this.inertia) {
-      await this.inertia
+    const fiber = this.ctx.fiber
+    while (fiber.inertia) {
+      await fiber.inertia
     }
-    if (this._error) throw this._error
+    if (fiber._error) throw fiber._error
     return this
   }
 
   async restart() {
-    this.assertActive()
-    this._setEpoch(INACTIVE)
-    this._refresh()
-    await this.await()
+    const fiber = this.ctx.fiber
+    fiber.assertActive()
+    fiber._setEpoch(INACTIVE)
+    fiber._refresh(true)
+    await fiber.await()
   }
 
   update(config: any, noSave = false) {
-    this.assertActive()
-    config = resolveConfig(this.runtime!, config)
-    this.context.waterfall(this, 'internal/update', config, noSave, () => {
-      this.config = config
-      this._error = undefined
-      return this.restart()
+    const fiber = this.ctx.fiber
+    fiber.assertActive()
+    config = resolveConfig(fiber.runtime!, config)
+    const result = fiber.context.waterfall(fiber, 'internal/update', config, noSave, () => {
+      fiber.config = config
+      return fiber.restart()
     })
+    if (isPromiseLike(result)) Promise.resolve(result).catch(() => {})
   }
 }

--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -1,4 +1,4 @@
-import { Awaitable, defineProperty, Dict, isNullable } from 'cosmokit'
+import { Awaitable, defineProperty, Dict, isNullable, noop } from 'cosmokit'
 import { Context } from './context'
 import { Plugin } from './registry'
 import { buildOuterStack, composeError, DisposableList, getTraceable, isConstructor, isObject, isPromiseLike, symbols } from './utils'
@@ -85,45 +85,35 @@ interface DesiredSnapshot {
 // tracked separately so an A -> B -> A transition cannot revive work from A.
 type FiberEpoch = object | typeof INACTIVE
 
-function combineErrors(errors: unknown[], primary?: unknown) {
+function combineCleanupErrors(errors: unknown[]) {
   // Do not flatten user AggregateErrors: one cleanup callback owns one error.
-  // We only inspect nesting to avoid inserting the same primary error twice.
-  const contains = (error: unknown): boolean => {
-    if (error === primary) return true
-    return error instanceof AggregateError && error.errors.some(contains)
-  }
-  const combined = primary !== undefined && !errors.some(contains) ? [primary, ...errors] : errors
-  if (!combined.length) return
-  if (combined.length === 1) return combined[0]
-  return new AggregateError(combined, 'multiple lifecycle errors', primary === undefined ? undefined : { cause: primary })
+  if (!errors.length) return
+  if (errors.length === 1) return errors[0]
+  return new AggregateError(errors, 'multiple cleanup errors')
 }
 
 function dispatchFiberDisposal(context: Context, fiber: Fiber) {
-  // Fiber disposal notification is contained per observer. Structural
-  // cleanup must continue even if dispatch, a synchronous observer, or an
-  // async observer fails; the caller later combines these outcomes with
-  // cleanup failures.
+  // Disposal observers are diagnostic, not structural owners. Their failures
+  // are reported but never delay or reject the Fiber's own disposal.
   const args: any[] = ['internal/plugin', fiber]
   let callbacks: Function[]
   try {
     callbacks = context.events.dispatch('emit', args)
   } catch (error) {
-    return [Promise.resolve({ status: 'rejected' as const, reason: error })]
+    context.logger.error(error)
+    return
   }
 
-  const tasks: Promise<{ status: 'fulfilled' } | { status: 'rejected', reason: unknown }>[] = []
   for (const callback of callbacks) {
     try {
       const result = callback(...args)
-      tasks.push(Promise.resolve(result).then(
-        () => ({ status: 'fulfilled' as const }),
-        reason => ({ status: 'rejected' as const, reason }),
-      ))
+      if (isPromiseLike(result)) {
+        void Promise.resolve(result).catch(error => context.logger.error(error))
+      }
     } catch (error) {
-      tasks.push(Promise.resolve({ status: 'rejected' as const, reason: error }))
+      context.logger.error(error)
     }
   }
-  return tasks
 }
 
 export const enum FiberState {
@@ -159,6 +149,19 @@ interface ExecutionGate {
   reject: (reason: unknown) => void
 }
 
+const kEffectRecord = Symbol.for('cordis.effectRecord')
+
+type ManagedDisposable = Disposable & { [kEffectRecord]?: EffectRecord }
+
+function getEffectRecord(dispose: Disposable) {
+  return (dispose as ManagedDisposable)[kEffectRecord]
+}
+
+interface CleanupFailure {
+  error: unknown
+  source?: EffectRecord
+}
+
 class EffectRecord {
   readonly meta: EffectMeta
   readonly runner: EffectRunner<boolean>
@@ -166,6 +169,8 @@ class EffectRecord {
   readonly wrapper: AsyncDisposable<Promise<void>>
 
   private cleanups: Disposable[] = []
+  private cleanupFailures: CleanupFailure[] = []
+  private cleanupReported = false
   private executionState: EffectExecutionState = 'running'
   private executionError: unknown
   private executionTask?: Promise<void>
@@ -183,6 +188,7 @@ class EffectRecord {
     }
     this.dispose = () => this.startDisposal()
     this.wrapper = defineProperty(() => this.startDisposal(), symbols.effect, this.meta) as AsyncDisposable<Promise<void>>
+    defineProperty(this.wrapper, kEffectRecord, this)
     this.wrapper.then = (onFulfilled, onRejected) => {
       return this.waitForExecution().then(() => this.dispose).then(onFulfilled, onRejected)
     }
@@ -210,7 +216,7 @@ class EffectRecord {
         resolve = res
         reject = rej
       })
-      promise.catch(() => {})
+      promise.catch(noop)
       this.executionGate = { promise, resolve, reject }
     }
     return this.executionGate.promise
@@ -232,7 +238,7 @@ class EffectRecord {
       this.failExecution(reason, true)
       throw reason
     })
-    this.executionTask.catch(() => {})
+    this.executionTask.catch(noop)
   }
 
   failExecution(reason: unknown, report = false) {
@@ -240,15 +246,14 @@ class EffectRecord {
     this.executionError = reason
     this.executionGate?.reject(reason)
     if (report) this.owner.ctx.logger.error(reason)
-    // Execution failure is synchronous to the caller, while rollback remains
-    // owner-visible and may finish asynchronously.
-    this.startDisposal(reason).catch((error) => {
-      if (error !== reason) this.owner.ctx.logger.error(error)
-    })
+    // Execution and disposal are separate result channels. The execution
+    // error is delivered by throw/the thenable; structural owners only join
+    // cleanup and observe cleanup failures.
+    this.startDisposal().catch(error => this.reportCleanupFailures(error))
   }
 
   private runCleanups() {
-    const errors: unknown[] = []
+    const failures = this.cleanupFailures
     const pending = this.cleanups.splice(0).reverse()
     let index = 0
 
@@ -261,23 +266,25 @@ class EffectRecord {
             // Preserve strict LIFO ordering across async cleanup. Rejections
             // are recorded and do not veto the remaining cleanup callbacks.
             return Promise.resolve(result).then(next, (error) => {
-              errors.push(error)
+              const failure = { error, source: getEffectRecord(dispose) }
+              failures.push(failure)
               return next()
             })
           }
         } catch (error) {
-          errors.push(error)
+          const failure = { error, source: getEffectRecord(dispose) }
+          failures.push(failure)
         }
       }
     }
 
     const result = next()
-    return isPromiseLike(result) ? Promise.resolve(result).then(() => errors) : errors
+    return isPromiseLike(result) ? Promise.resolve(result).then(() => failures) : failures
   }
 
-  private finishDisposal(primary?: unknown) {
-    const finalize = (errors: unknown[]) => {
-      const error = combineErrors(errors, primary)
+  private finishDisposal() {
+    const finalize = (failures: CleanupFailure[]) => {
+      const error = combineCleanupErrors(failures.map(failure => failure.error))
       return error ? Promise.reject<void>(error) : Promise.resolve()
     }
     const result = this.runCleanups()
@@ -285,7 +292,7 @@ class EffectRecord {
     return { task: finalize(result), synchronous: true }
   }
 
-  private startDisposal(primary?: unknown) {
+  private startDisposal() {
     // Public callers and structural owners always join the first task; cleanup
     // itself is exactly-once.
     if (this.disposalTask) return this.disposalTask
@@ -293,14 +300,12 @@ class EffectRecord {
 
     let task: Promise<void>
     let synchronous = false
-    if (this.executionState === 'fulfilled') {
-      ;({ task, synchronous } = this.finishDisposal(primary))
-    } else if (this.executionState === 'rejected') {
-      ;({ task, synchronous } = this.finishDisposal(primary ?? this.executionError))
+    if (this.executionState === 'fulfilled' || this.executionState === 'rejected') {
+      ;({ task, synchronous } = this.finishDisposal())
     } else {
       task = this.waitForExecution().then(
-        () => this.finishDisposal(primary).task,
-        error => this.finishDisposal(primary ?? error).task,
+        () => this.finishDisposal().task,
+        () => this.finishDisposal().task,
       )
     }
 
@@ -318,8 +323,24 @@ class EffectRecord {
         },
       )
     }
-    this.disposalTask.catch(() => {})
+    this.disposalTask.catch(noop)
     return this.disposalTask
+  }
+
+  reportCleanupFailures(fallback?: unknown) {
+    if (this.cleanupReported) return
+    this.cleanupReported = true
+    if (!this.cleanupFailures.length) {
+      if (fallback !== undefined) this.owner.ctx.logger.error(fallback)
+      return
+    }
+    for (const failure of this.cleanupFailures) {
+      if (failure.source) {
+        failure.source.reportCleanupFailures(failure.error)
+      } else {
+        this.owner.ctx.logger.error(failure.error)
+      }
+    }
   }
 }
 
@@ -339,6 +360,7 @@ export class Fiber {
   protected context: Context
 
   private _error: any
+  private _configError: unknown
   private _runner: EffectRunner<FiberEpoch>
   private _store: Dict<Impl> = Object.create(null)
   private _desired?: DesiredSnapshot
@@ -395,13 +417,11 @@ export class Fiber {
           shouldRefresh = true
         } catch (error) {
           this.ctx.logger.error(error)
-          this._error = error
+          this._error = this._configError = error
         }
         return async () => {
           this.uid = null
-          // Start observers before structural cleanup, but await both together
-          // so neither can starve the other and all failures remain visible.
-          const notificationTasks = dispatchFiberDisposal(this.context, this)
+          dispatchFiberDisposal(this.context, this)
           if (this.ctx.registry.has(runtime.callback)) {
             remove()
             if (!runtime.fibers.length) {
@@ -415,19 +435,7 @@ export class Fiber {
               return FiberState.UNLOADING
             })
           }
-          const lifecycleTask = (async () => {
-            while (this.inertia) await this.inertia
-          })()
-          const [notifications, lifecycle] = await Promise.all([
-            Promise.all(notificationTasks),
-            lifecycleTask.then(() => ({ status: 'fulfilled' as const }), reason => ({ status: 'rejected' as const, reason })),
-          ])
-          const errors = notifications
-            .filter((result): result is { status: 'rejected', reason: unknown } => result.status === 'rejected')
-            .map(result => result.reason)
-          if (lifecycle.status === 'rejected') errors.push(lifecycle.reason)
-          const error = combineErrors(errors)
-          if (error) throw error
+          while (this.inertia) await this.inertia
         }
       }, 'ctx.plugin()')
 
@@ -592,7 +600,7 @@ export class Fiber {
     // Attach an observer so internally scheduled transitions never become
     // process-level unhandled rejections. Return the original task unchanged;
     // fiber.await() can still observe the same rejection.
-    task.catch(() => {})
+    task.catch(noop)
     return task
   }
 
@@ -606,7 +614,9 @@ export class Fiber {
   _refresh(force = false) {
     if (this.uid === null) return
     const implementations: Impl[] = []
-    let loadable = true
+    // Dependency availability cannot recover an invalid configuration. Only a
+    // successfully validated explicit update clears _configError.
+    let loadable = this._configError === undefined
     for (const name of Object.keys(this.inject)) {
       const impl = this._store[name]
       if (!impl) {
@@ -676,35 +686,32 @@ export class Fiber {
     })
   }
 
-  private async _unload(primary?: unknown) {
-    // Top-level effects may clean up concurrently. Promise.all preserves input
-    // order, giving deterministic error aggregation independent of settlement.
-    const outcomes = await Promise.all(this._disposables.clear().map(async (dispose) => {
-      try {
-        await composeError(async (info) => {
-          await Promise.resolve()
-          info.error = new Error()
-          await dispose()
-        }, this._runner.getOuterStack)
-        return { status: 'fulfilled' as const }
-      } catch (reason) {
-        return { status: 'rejected' as const, reason }
-      }
+  private async _unload(executionError?: unknown) {
+    // Top-level effects clean up concurrently. Each rejection is contained at
+    // the structural boundary, so Promise.all only waits for quiescence.
+    await Promise.all(this._disposables.clear().map((dispose) => {
+      return composeError(async (info) => {
+        await Promise.resolve()
+        info.error = new Error()
+        await dispose()
+      }, this._runner.getOuterStack).catch((reason) => {
+        const record = getEffectRecord(dispose)
+        if (record) {
+          record.reportCleanupFailures(reason)
+        } else {
+          this.ctx.logger.error(reason)
+        }
+      })
     }))
-    const errors = outcomes
-      .filter((outcome): outcome is { status: 'rejected', reason: unknown } => outcome.status === 'rejected')
-      .map(outcome => outcome.reason)
-    const error = combineErrors(errors, primary)
 
     this.store = undefined
     this._updateState(() => {
-      // Terminal disposal always reaches DISPOSED. For non-terminal failures,
-      // stop the pump in FAILED rather than activating a replacement on top of
-      // resources whose cleanup may have failed.
+      // Cleanup failures have already been contained above. Only an execution
+      // failure stops a non-terminal Fiber in FAILED.
       if (this.uid === null) {
         this.inertia = undefined
-      } else if (error) {
-        this._error = error
+      } else if (executionError !== undefined) {
+        this._error = executionError
         this._runner.epoch = INACTIVE
         this.inertia = undefined
       } else if (this._runner.epoch === INACTIVE) {
@@ -714,7 +721,7 @@ export class Fiber {
         return FiberState.LOADING
       }
     })
-    if (error) throw error
+    if (executionError !== undefined) throw executionError
   }
 
   async await() {
@@ -738,10 +745,15 @@ export class Fiber {
     const fiber = this.ctx.fiber
     fiber.assertActive()
     config = resolveConfig(fiber.runtime!, config)
-    const result = fiber.context.waterfall(fiber, 'internal/update', config, noSave, () => {
+    return fiber.context.waterfall(fiber, 'internal/update', config, noSave, () => {
+      const configError = fiber._configError
       fiber.config = config
+      fiber._configError = undefined
+      if (configError !== undefined && fiber._error === configError) {
+        fiber._error = undefined
+        fiber._updateState(() => {})
+      }
       return fiber.restart()
     })
-    if (isPromiseLike(result)) Promise.resolve(result).catch(() => {})
   }
 }

--- a/packages/core/src/reflect.ts
+++ b/packages/core/src/reflect.ts
@@ -193,11 +193,19 @@ export class ReflectService {
         this.notify([name])
       }
       return async () => {
-        delete this.store[key]
+        // A stale provider cleanup must never remove a replacement Impl that
+        // was installed under the same isolated service key.
+        if (this.store[key] === impl) delete this.store[key]
         const fibers = this.notify([name])
-        await Promise.allSettled(fibers.map(fiber => fiber.await()))
-        // ensure self access before dependencies cleanup
-        delete this.ctx.fiber.store![name]
+        const outcomes = await Promise.allSettled(fibers.map(fiber => fiber.await()))
+        // Ensure self access before dependencies cleanup, with the same
+        // incarnation guard for the provider Fiber's captured store.
+        if (this.ctx.fiber.store![name] === impl) delete this.ctx.fiber.store![name]
+        const errors = outcomes
+          .filter((outcome): outcome is PromiseRejectedResult => outcome.status === 'rejected')
+          .map(outcome => outcome.reason)
+        if (errors.length === 1) throw errors[0]
+        if (errors.length > 1) throw new AggregateError(errors, 'dependent fibers failed to settle')
       }
     }, `ctx.provide(${JSON.stringify(name)})`)
   }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -97,6 +97,10 @@ export function isObject(value: any): value is {} {
   return value && (typeof value === 'object' || typeof value === 'function')
 }
 
+export function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return isObject(value) && 'then' in value
+}
+
 export function getPropertyDescriptor(target: any, prop: string | symbol) {
   let proto = target
   while (proto) {
@@ -259,7 +263,7 @@ export function composeError<T>(callback: (info: StackInfo) => T, getOuterStack 
 
   try {
     const result: any = callback(info)
-    if (isObject(result) && 'then' in result) {
+    if (isPromiseLike(result)) {
       return (result as any).then(undefined, (reason) => handleError(info, reason, getOuterStack)) as T
     } else {
       return result

--- a/packages/core/tests/dispose.spec.ts
+++ b/packages/core/tests/dispose.spec.ts
@@ -219,7 +219,7 @@ describe('Effects', () => {
       return () => seq.push(1)
     })
     expect(seq).to.deep.equal([])
-    await expect(dispose).rejects.toThrow()
+    await expect(Promise.resolve(dispose)).rejects.toThrow()
     expect(seq).to.deep.equal([])
   })
 
@@ -307,8 +307,33 @@ describe('Effects', () => {
     expect(error.errors).to.deep.equal([other, nested])
   })
 
-  it('keeps execution failure primary when rollback cleanup also fails', async () => {
+  it('keeps a direct cleanup failure observable through the shared promise', async () => {
     const root = new Context()
+    const error = new Error('cleanup failed')
+    const dispose = root.effect(() => () => { throw error })
+
+    const task = dispose()
+    expect(dispose()).to.equal(task)
+    await expect(task).rejects.toBe(error)
+    await expect(dispose()).rejects.toBe(error)
+  })
+
+  it('contains cleanup failure at structural restart', async () => {
+    const root = new Context()
+    const error = new Error('cleanup failed')
+    const logged: unknown[] = []
+    ;(root.logger as any).error = (value: unknown) => { logged.push(value) }
+    root.effect(() => () => { throw error })
+
+    await expect(root.fiber.restart()).resolves.toBeUndefined()
+    expect(root.fiber.state).to.equal(FiberState.ACTIVE)
+    expect(logged).to.deep.equal([error])
+  })
+
+  it('separates synchronous execution and rollback cleanup failures', async () => {
+    const root = new Context()
+    const logged: unknown[] = []
+    ;(root.logger as any).error = (error: unknown) => { logged.push(error) }
     const executionError = new Error('execution failed')
     const cleanupError = new Error('cleanup failed')
     let restarting!: Promise<void>
@@ -319,11 +344,9 @@ describe('Effects', () => {
       throw executionError
     })).to.throw(executionError)
 
-    const error = await restarting.catch(error => error)
-    expect(error).to.be.instanceOf(AggregateError)
-    expect(error.cause).to.equal(executionError)
-    expect(error.errors[0]).to.equal(executionError)
-    expect(error.errors).to.include(cleanupError)
+    await expect(restarting).resolves.toBeUndefined()
+    expect(root.fiber.state).to.equal(FiberState.ACTIVE)
+    expect(logged).to.deep.equal([cleanupError])
   })
 
   it('removes a synchronously failed effect after rolling back collected cleanup', () => {
@@ -339,7 +362,7 @@ describe('Effects', () => {
     expect(root.fiber.getEffects()).to.deep.equal([])
   })
 
-  it('makes reentrant restart await async rollback and reject the execution failure', async () => {
+  it('makes reentrant restart await async rollback without replaying the execution failure', async () => {
     const root = new Context()
     const cleanupGate = Promise.withResolvers<void>()
     const cleanupStarted = Promise.withResolvers<void>()
@@ -362,8 +385,42 @@ describe('Effects', () => {
     expect(settled).to.be.false
 
     cleanupGate.resolve()
-    await expect(restarting).rejects.toBe(executionError)
+    await expect(restarting).resolves.toBeUndefined()
     expect(root.fiber.getEffects()).to.deep.equal([])
+  })
+
+  it('separates asynchronous execution and disposal failures', async () => {
+    const root = new Context()
+    const executionError = new Error('execution failed')
+    const cleanupError = new Error('cleanup failed')
+    const effect = root.effect(async function* () {
+      yield () => { throw cleanupError }
+      throw executionError
+    })
+
+    await expect(Promise.resolve(effect)).rejects.toBe(executionError)
+    await expect(effect()).rejects.toBe(cleanupError)
+  })
+
+  it('logs auto-rollback cleanup failure once when a structural owner joins', async () => {
+    const root = new Context()
+    const logged: unknown[] = []
+    ;(root.logger as any).error = (error: unknown) => { logged.push(error) }
+    const restartStarted = Promise.withResolvers<void>()
+    const executionError = new Error('execution failed')
+    const cleanupError = new Error('cleanup failed')
+    let restarting!: Promise<void>
+    const effect = root.effect(async function* () {
+      yield () => { throw cleanupError }
+      restarting = root.fiber.restart()
+      restartStarted.resolve()
+      throw executionError
+    })
+
+    await restartStarted.promise
+    await expect(Promise.resolve(effect)).rejects.toBe(executionError)
+    await expect(restarting).resolves.toBeUndefined()
+    expect(logged).to.deep.equal([executionError, cleanupError])
   })
 
   it('makes reentrant restart await async execution and cleanup', async () => {

--- a/packages/core/tests/dispose.spec.ts
+++ b/packages/core/tests/dispose.spec.ts
@@ -1,4 +1,4 @@
-import { Context } from '../src'
+import { Context, CordisError, FiberState } from '../src'
 import { expect, describe, it, vi } from 'vitest'
 import { mock } from 'node:test'
 import { sleep, withTimers } from './utils'
@@ -14,7 +14,9 @@ describe('Effects', () => {
       { label: 'test', children: [] },
     ])
     expect(dispose.mock.calls).to.have.length(0)
-    await fiber.dispose()
+    const task = fiber.dispose()
+    expect(fiber.dispose()).to.equal(task)
+    await task
     expect(dispose.mock.calls).to.have.length(1)
     await fiber.dispose()
     expect(dispose.mock.calls).to.have.length(1)
@@ -67,9 +69,11 @@ describe('Effects', () => {
       { label: 'ctx.on("custom-event")', children: [] },
     ])
     expect(seq).to.deep.equal([])
-    dispose()
+    const task = dispose()
+    expect(dispose()).to.equal(task)
+    await task
     expect(seq).to.deep.equal([3, 2, 1])
-    dispose()
+    await dispose()
     expect(seq).to.deep.equal([3, 2, 1])
   })
 
@@ -236,5 +240,195 @@ describe('Effects', () => {
     }
     expect(caught).to.be.instanceOf(Error)
     expect(seq).to.deep.equal([1])
+  })
+
+  it('returns one disposal promise and joins cleanup already in progress', async () => {
+    const root = new Context()
+    const gate = Promise.withResolvers<void>()
+    let cleanupStarted = false
+    const dispose = root.effect(() => async () => {
+      cleanupStarted = true
+      await gate.promise
+    })
+
+    const first = dispose()
+    const second = dispose()
+    expect(first).to.equal(second)
+    expect(cleanupStarted).to.be.true
+
+    const restarting = root.fiber.restart()
+    let settled = false
+    void restarting.then(() => { settled = true })
+    await Promise.resolve()
+    expect(settled).to.be.false
+
+    gate.resolve()
+    await Promise.all([first, restarting])
+    expect(dispose()).to.equal(first)
+  })
+
+  it('attempts every cleanup in LIFO order and aggregates failures deterministically', async () => {
+    const root = new Context()
+    const sequence: number[] = []
+    const first = new Error('first')
+    const third = new Error('third')
+    const dispose = root.effect(function* () {
+      yield () => {
+        sequence.push(1)
+        throw first
+      }
+      yield async () => {
+        await Promise.resolve()
+        sequence.push(2)
+      }
+      yield () => {
+        sequence.push(3)
+        throw third
+      }
+    })
+
+    const error = await dispose().catch(error => error)
+    expect(sequence).to.deep.equal([3, 2, 1])
+    expect(error).to.be.instanceOf(AggregateError)
+    expect(error.errors).to.deep.equal([third, first])
+  })
+
+  it('preserves an AggregateError thrown by user cleanup as one failure', async () => {
+    const root = new Context()
+    const nested = new AggregateError([new Error('a'), new Error('b')], 'user aggregate')
+    const other = new Error('other')
+    const dispose = root.effect(function* () {
+      yield () => { throw nested }
+      yield () => { throw other }
+    })
+
+    const error = await dispose().catch(error => error)
+    expect(error).to.be.instanceOf(AggregateError)
+    expect(error.errors).to.deep.equal([other, nested])
+  })
+
+  it('keeps execution failure primary when rollback cleanup also fails', async () => {
+    const root = new Context()
+    const executionError = new Error('execution failed')
+    const cleanupError = new Error('cleanup failed')
+    let restarting!: Promise<void>
+
+    expect(() => root.effect(function* () {
+      yield () => { throw cleanupError }
+      restarting = root.fiber.restart()
+      throw executionError
+    })).to.throw(executionError)
+
+    const error = await restarting.catch(error => error)
+    expect(error).to.be.instanceOf(AggregateError)
+    expect(error.cause).to.equal(executionError)
+    expect(error.errors[0]).to.equal(executionError)
+    expect(error.errors).to.include(cleanupError)
+  })
+
+  it('removes a synchronously failed effect after rolling back collected cleanup', () => {
+    const root = new Context()
+    let cleanups = 0
+
+    expect(() => root.effect(function* () {
+      yield () => { cleanups += 1 }
+      throw new Error('execution failed')
+    })).to.throw('execution failed')
+
+    expect(cleanups).to.equal(1)
+    expect(root.fiber.getEffects()).to.deep.equal([])
+  })
+
+  it('makes reentrant restart await async rollback and reject the execution failure', async () => {
+    const root = new Context()
+    const cleanupGate = Promise.withResolvers<void>()
+    const cleanupStarted = Promise.withResolvers<void>()
+    const executionError = new Error('execution failed')
+    let restarting!: Promise<void>
+
+    expect(() => root.effect(function* () {
+      yield async () => {
+        cleanupStarted.resolve()
+        await cleanupGate.promise
+      }
+      restarting = root.fiber.restart()
+      throw executionError
+    })).to.throw(executionError)
+
+    await cleanupStarted.promise
+    let settled = false
+    void restarting.finally(() => { settled = true }).catch(() => {})
+    await Promise.resolve()
+    expect(settled).to.be.false
+
+    cleanupGate.resolve()
+    await expect(restarting).rejects.toBe(executionError)
+    expect(root.fiber.getEffects()).to.deep.equal([])
+  })
+
+  it('makes reentrant restart await async execution and cleanup', async () => {
+    const root = new Context()
+    const executionGate = Promise.withResolvers<void>()
+    const cleanupGate = Promise.withResolvers<void>()
+    const cleanupStarted = Promise.withResolvers<void>()
+    let restarting!: Promise<void>
+
+    root.effect(async () => {
+      restarting = root.fiber.restart()
+      await executionGate.promise
+      return async () => {
+        cleanupStarted.resolve()
+        await cleanupGate.promise
+      }
+    })
+
+    executionGate.resolve()
+    await cleanupStarted.promise
+    let settled = false
+    void restarting.then(() => { settled = true })
+    await Promise.resolve()
+    expect(settled).to.be.false
+
+    cleanupGate.resolve()
+    await restarting
+    expect(root.fiber.getEffects()).to.deep.equal([])
+  })
+
+  it('rejects effect registration during unload', async () => {
+    const root = new Context()
+    let registrationError: unknown
+    root.effect(() => () => {
+      try {
+        root.effect(() => () => {})
+      } catch (error) {
+        registrationError = error
+      }
+    })
+
+    await root.fiber.restart()
+    expect(registrationError).to.be.instanceOf(CordisError)
+    expect((registrationError as CordisError).code).to.equal('INACTIVE_EFFECT')
+    expect(root.fiber.state).to.equal(FiberState.ACTIVE)
+  })
+
+  it('accepts effects while a child is pending or loading', async () => {
+    const root = new Context()
+    const cleaned: string[] = []
+    root.on('internal/plugin', (fiber) => {
+      if (fiber.name !== 'state-probe' || fiber.uid === null) return
+      expect(fiber.state).to.equal(FiberState.PENDING)
+      fiber.ctx.effect(() => () => { cleaned.push('pending') })
+    })
+
+    const fiber = await root.plugin({
+      name: 'state-probe',
+      apply(ctx) {
+        expect(ctx.fiber.state).to.equal(FiberState.LOADING)
+        ctx.effect(() => () => { cleaned.push('loading') })
+      },
+    })
+    await fiber.dispose()
+
+    expect(cleaned).to.have.members(['pending', 'loading'])
   })
 })

--- a/packages/core/tests/fiber.spec.ts
+++ b/packages/core/tests/fiber.spec.ts
@@ -1,4 +1,4 @@
-import { Context, FiberState, Service, type Fiber } from '../src'
+import { Context, FiberState, Service, ValidationError, type Fiber } from '../src'
 import { expect, describe, it, vi } from 'vitest'
 import { mock } from 'node:test'
 import { event, sleep, withTimers } from './utils'
@@ -91,6 +91,23 @@ describe('Fiber', () => {
     expect(callback.mock.calls).to.have.length(1)
   })
 
+  it('keeps plugin execution failure separate from rollback cleanup failure', async () => {
+    const root = new Context()
+    const logged: unknown[] = []
+    ;(root.logger as any).error = (error: unknown) => { logged.push(error) }
+    const executionError = new Error('execution failed')
+    const cleanupError = new Error('cleanup failed')
+    const fiber = root.plugin((ctx) => {
+      ctx.effect(() => () => { throw cleanupError })
+      throw executionError
+    })
+
+    const error = await fiber.await().catch(error => error)
+    expect(error).to.equal(executionError)
+    expect(logged).to.deep.equal([executionError, cleanupError])
+    expect(fiber.state).to.equal(FiberState.FAILED)
+  })
+
   it('dispose error', async () => {
     const root = new Context()
     const error = mock.fn()
@@ -104,10 +121,11 @@ describe('Fiber', () => {
 
     const fiber = await root.plugin(plugin)
     expect(dispose.mock.calls).to.have.length(0)
-    await expect(fiber.dispose()).rejects.toThrow('test')
+    await expect(fiber.dispose()).resolves.toBeUndefined()
     await sleep()
     expect(dispose.mock.calls).to.have.length(1)
-    expect(error.mock.calls).to.have.length(0)
+    expect(error.mock.calls).to.have.length(1)
+    expect(error.mock.calls[0].arguments[0]).to.have.property('message', 'test')
   })
 
   it('update config on wrapped fiber', async () => {
@@ -119,15 +137,42 @@ describe('Fiber', () => {
     expect(callback.mock.calls).to.have.length(1)
     expect(callback.mock.calls[0].arguments[1]).to.deep.equal({ msg: 'hello' })
 
-    fiber.update({ msg: 'world' })
-    await fiber
+    await fiber.update({ msg: 'world' })
     expect(callback.mock.calls).to.have.length(2)
     expect(callback.mock.calls[1].arguments[1]).to.deep.equal({ msg: 'world' })
 
-    fiber.update({ msg: '!!!' })
-    await fiber
+    await fiber.update({ msg: '!!!' })
     expect(callback.mock.calls).to.have.length(3)
     expect(callback.mock.calls[2].arguments[1]).to.deep.equal({ msg: '!!!' })
+  })
+
+  it('returns the asynchronous internal/update waterfall result', async () => {
+    const root = new Context()
+    const gate = Promise.withResolvers<void>()
+    const started = Promise.withResolvers<void>()
+    const configs: string[] = []
+    const fiber = root.plugin((_ctx, config: { value: string }) => {
+      configs.push(config.value)
+    }, { value: 'old' })
+    await fiber
+
+    fiber.ctx.on('internal/update', async (_config, _noSave, next) => {
+      started.resolve()
+      await gate.promise
+      return next()
+    })
+    const update = fiber.update({ value: 'new' })
+    await started.promise
+
+    let settled = false
+    void Promise.resolve(update).then(() => { settled = true })
+    await fiber.await()
+    expect(settled).to.be.false
+    expect(configs).to.deep.equal(['old'])
+
+    gate.resolve()
+    await update
+    expect(configs).to.deep.equal(['old', 'new'])
   })
 
   it('keeps wrapped fiber state canonical across restart and update', async () => {
@@ -139,8 +184,7 @@ describe('Fiber', () => {
 
     await fiber
     await fiber.restart()
-    fiber.update({ value: 'second' })
-    await fiber
+    await fiber.update({ value: 'second' })
 
     const canonical = Object.getPrototypeOf(fiber)
     expect(configs).to.deep.equal(['first', 'first', 'second'])
@@ -158,35 +202,97 @@ describe('Fiber', () => {
       configs.push(config.value)
     }, { value: 'old' })
 
-    fiber.update({ value: 'new' })
-    await fiber
+    await fiber.update({ value: 'new' })
 
     expect(configs).to.deep.equal(['new'])
     expect(fiber.state).to.equal(FiberState.ACTIVE)
   })
 
-  it('fails a restart after cleanup errors and allows a later generation to recover', async () => {
+  it('does not clear config validation failure when dependencies become available', async () => {
+    const root = new Context()
+    const configs: any[] = []
+    const Config = {
+      '~standard': {
+        version: 1,
+        vendor: 'test',
+        validate(config: any) {
+          return typeof config?.value === 'string'
+            ? { value: config }
+            : { issues: [{ message: 'value is required' }] }
+        },
+      },
+    } as any
+    const fiber = root.plugin({
+      inject: ['ready'],
+      Config,
+      apply(_ctx, config) { configs.push(config) },
+    }, {})
+
+    root.provide('ready', true)
+    await expect(Promise.resolve(fiber)).rejects.toBeInstanceOf(ValidationError)
+    expect(fiber.state).to.equal(FiberState.FAILED)
+    expect(configs).to.deep.equal([])
+
+    await fiber.update({ value: 'valid' })
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+    expect(configs).to.deep.equal([{ value: 'valid' }])
+  })
+
+  it('clears config validation failure after a valid update while dependencies remain unavailable', async () => {
+    const root = new Context()
+    const configs: any[] = []
+    const Config = {
+      '~standard': {
+        version: 1,
+        vendor: 'test',
+        validate(config: any) {
+          return typeof config?.value === 'string'
+            ? { value: config }
+            : { issues: [{ message: 'value is required' }] }
+        },
+      },
+    } as any
+    const fiber = root.plugin({
+      inject: ['ready'],
+      Config,
+      apply(_ctx, config) { configs.push(config) },
+    }, {})
+
+    await expect(Promise.resolve(fiber)).rejects.toBeInstanceOf(ValidationError)
+    await fiber.update({ value: 'valid' })
+    expect(fiber.state).to.equal(FiberState.PENDING)
+    expect(configs).to.deep.equal([])
+
+    root.provide('ready', true)
+    await fiber
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+    expect(configs).to.deep.equal([{ value: 'valid' }])
+  })
+
+  it('continues the next generation after cleanup errors', async () => {
     const root = new Context()
     const configs: string[] = []
+    const logged: unknown[] = []
+    ;(root.logger as any).error = (error: unknown) => { logged.push(error) }
+    const cleanupError = new Error('cleanup failed')
     let failCleanup = true
     const fiber = root.plugin((_ctx, config: { value: string }) => {
       configs.push(config.value)
       return () => {
-        if (failCleanup) throw new Error('cleanup failed')
+        if (failCleanup) throw cleanupError
       }
     }, { value: 'old' })
     await fiber
 
-    fiber.update({ value: 'blocked' })
-    await expect(fiber.await()).rejects.toThrow('cleanup failed')
-    expect(fiber.state).to.equal(FiberState.FAILED)
-    expect(configs).to.deep.equal(['old'])
+    await fiber.update({ value: 'blocked' })
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+    expect(configs).to.deep.equal(['old', 'blocked'])
+    expect(logged).to.deep.equal([cleanupError])
 
     failCleanup = false
-    fiber.update({ value: 'recovered' })
-    await fiber
+    await fiber.update({ value: 'recovered' })
     expect(fiber.state).to.equal(FiberState.ACTIVE)
-    expect(configs).to.deep.equal(['old', 'recovered'])
+    expect(configs).to.deep.equal(['old', 'blocked', 'recovered'])
   })
 
   it('does not let a stale execution failure poison the current generation', async () => {
@@ -204,9 +310,9 @@ describe('Fiber', () => {
     }, { value: 'old' })
 
     while (!configs.length) await Promise.resolve()
-    fiber.update({ value: 'new' })
+    const update = fiber.update({ value: 'new' })
     gate.resolve()
-    await fiber
+    await update
 
     expect(configs).to.deep.equal(['old', 'new'])
     expect(fiber.state).to.equal(FiberState.ACTIVE)
@@ -303,8 +409,10 @@ describe('Fiber publication ownership', () => {
     expect(root.registry.has(plugin)).to.be.false
   })
 
-  it('contains disposal observers, finishes cleanup, and rejects disposal', async () => {
+  it('logs disposal observer failures without rejecting disposal', async () => {
     const root = new Context()
+    const errors = mock.fn()
+    ;(root.logger as any).error = errors
     const observed: string[] = []
     root.on('internal/plugin', (fiber) => {
       if (fiber.name === 'observed' && fiber.uid === null) throw new Error('observer failed')
@@ -314,17 +422,25 @@ describe('Fiber publication ownership', () => {
     })
     const fiber = await root.plugin({ name: 'observed', apply() {} })
 
-    await expect(fiber.dispose()).rejects.toThrow('observer failed')
+    await expect(fiber.dispose()).resolves.toBeUndefined()
     expect(observed).to.deep.equal(['disposed'])
+    expect(errors.mock.calls).to.have.length(1)
+    expect(errors.mock.calls[0].arguments[0]).to.have.property('message', 'observer failed')
     expect(fiber.state).to.equal(FiberState.DISPOSED)
   })
 
-  it('settles disposal observers and cleanup together with stable error order', async () => {
+  it('does not await async disposal observers but still observes rejections', async () => {
     const root = new Context()
     const observerGate = Promise.withResolvers<void>()
+    const observerLogged = Promise.withResolvers<void>()
     const cleanupGate = Promise.withResolvers<void>()
     const observerError = new Error('observer')
     const cleanupError = new Error('cleanup')
+    const logged: unknown[] = []
+    ;(root.logger as any).error = (error: unknown) => {
+      logged.push(error)
+      if (error === observerError) observerLogged.resolve()
+    }
     let observerStarted = false
     let cleanupStarted = false
     root.on('internal/plugin', async (fiber) => {
@@ -350,11 +466,13 @@ describe('Fiber publication ownership', () => {
     expect(cleanupStarted).to.be.true
 
     cleanupGate.resolve()
-    observerGate.resolve()
-    const error = await disposal.catch(error => error)
-    expect(error).to.be.instanceOf(AggregateError)
-    expect(error.errors).to.deep.equal([observerError, cleanupError])
+    await expect(disposal).resolves.toBeUndefined()
     expect(fiber.state).to.equal(FiberState.DISPOSED)
+    expect(logged).to.deep.equal([cleanupError])
+
+    observerGate.resolve()
+    await observerLogged.promise
+    expect(logged).to.deep.equal([cleanupError, observerError])
   })
 
   it('lets parent disposal during publication drain pending child effects', async () => {

--- a/packages/core/tests/fiber.spec.ts
+++ b/packages/core/tests/fiber.spec.ts
@@ -1,4 +1,4 @@
-import { Context, FiberState, Service } from '../src'
+import { Context, FiberState, Service, type Fiber } from '../src'
 import { expect, describe, it, vi } from 'vitest'
 import { mock } from 'node:test'
 import { event, sleep, withTimers } from './utils'
@@ -24,9 +24,11 @@ describe('Fiber', () => {
     expect(fiber.state).to.equal(FiberState.ACTIVE)
   }))
 
-  it('inertia lock 2', withTimers(async (root) => {
+  it('reloads when an implementation is replaced during loading', withTimers(async (root) => {
     const dispose = root.provide('foo', 1)
-    const fiber = root.inject(['foo'], async () => {
+    const values: number[] = []
+    const fiber = root.inject(['foo'], async (ctx) => {
+      values.push(ctx.foo)
       await sleep(1000)
       return () => sleep(1000)
     })
@@ -37,7 +39,12 @@ describe('Fiber', () => {
     expect(fiber.state).to.equal(FiberState.LOADING)
     root.provide('foo', 2)
     await vi.advanceTimersByTimeAsync(400) // 1200
+    expect(fiber.state).to.equal(FiberState.UNLOADING)
+    await vi.advanceTimersByTimeAsync(1000) // 2200
+    expect(fiber.state).to.equal(FiberState.LOADING)
+    await vi.advanceTimersByTimeAsync(1000) // 3200
     expect(fiber.state).to.equal(FiberState.ACTIVE)
+    expect(values).to.deep.equal([1, 2])
   }))
 
   it('inertia lock 3', withTimers(async (root) => {
@@ -97,10 +104,10 @@ describe('Fiber', () => {
 
     const fiber = await root.plugin(plugin)
     expect(dispose.mock.calls).to.have.length(0)
-    await expect(fiber.dispose()).resolves.toBeUndefined()
+    await expect(fiber.dispose()).rejects.toThrow('test')
     await sleep()
     expect(dispose.mock.calls).to.have.length(1)
-    expect(error.mock.calls).to.have.length(1)
+    expect(error.mock.calls).to.have.length(0)
   })
 
   it('update config on wrapped fiber', async () => {
@@ -121,5 +128,314 @@ describe('Fiber', () => {
     await fiber
     expect(callback.mock.calls).to.have.length(3)
     expect(callback.mock.calls[2].arguments[1]).to.deep.equal({ msg: '!!!' })
+  })
+
+  it('keeps wrapped fiber state canonical across restart and update', async () => {
+    const root = new Context()
+    const configs: string[] = []
+    const fiber = root.plugin((_ctx, config: { value: string }) => {
+      configs.push(config.value)
+    }, { value: 'first' })
+
+    await fiber
+    await fiber.restart()
+    fiber.update({ value: 'second' })
+    await fiber
+
+    const canonical = Object.getPrototypeOf(fiber)
+    expect(configs).to.deep.equal(['first', 'first', 'second'])
+    expect(fiber.state).to.equal(canonical.state)
+    expect(fiber.config).to.equal(canonical.config)
+    expect(Object.hasOwn(fiber, 'state')).to.be.false
+    expect(Object.hasOwn(fiber, 'config')).to.be.false
+    expect(Object.hasOwn(fiber, 'inertia')).to.be.false
+  })
+
+  it('coalesces an update before initial apply into a new generation', async () => {
+    const root = new Context()
+    const configs: string[] = []
+    const fiber = root.plugin((_ctx, config: { value: string }) => {
+      configs.push(config.value)
+    }, { value: 'old' })
+
+    fiber.update({ value: 'new' })
+    await fiber
+
+    expect(configs).to.deep.equal(['new'])
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+  })
+
+  it('fails a restart after cleanup errors and allows a later generation to recover', async () => {
+    const root = new Context()
+    const configs: string[] = []
+    let failCleanup = true
+    const fiber = root.plugin((_ctx, config: { value: string }) => {
+      configs.push(config.value)
+      return () => {
+        if (failCleanup) throw new Error('cleanup failed')
+      }
+    }, { value: 'old' })
+    await fiber
+
+    fiber.update({ value: 'blocked' })
+    await expect(fiber.await()).rejects.toThrow('cleanup failed')
+    expect(fiber.state).to.equal(FiberState.FAILED)
+    expect(configs).to.deep.equal(['old'])
+
+    failCleanup = false
+    fiber.update({ value: 'recovered' })
+    await fiber
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+    expect(configs).to.deep.equal(['old', 'recovered'])
+  })
+
+  it('does not let a stale execution failure poison the current generation', async () => {
+    const root = new Context()
+    const errors = mock.fn()
+    ;(root.logger as any).error = errors
+    const gate = Promise.withResolvers<void>()
+    const configs: string[] = []
+    const fiber = root.plugin(async (_ctx, config: { value: string }) => {
+      configs.push(config.value)
+      if (config.value === 'old') {
+        await gate.promise
+        throw new Error('stale execution')
+      }
+    }, { value: 'old' })
+
+    while (!configs.length) await Promise.resolve()
+    fiber.update({ value: 'new' })
+    gate.resolve()
+    await fiber
+
+    expect(configs).to.deep.equal(['old', 'new'])
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+    expect(errors.mock.calls).to.have.length(1)
+  })
+
+  it('does not revive a generation across an availability ABA transition', withTimers(async (root) => {
+    let available = true
+    const values: number[] = []
+    root.reflect.provide('foo', 1, () => available)
+    const fiber = root.inject(['foo'], async (ctx) => {
+      values.push(ctx.foo)
+      await sleep(1000)
+      return () => sleep(1000)
+    })
+
+    await vi.advanceTimersByTimeAsync(400)
+    available = false
+    root.reflect.notify(['foo'])
+    await vi.advanceTimersByTimeAsync(400)
+    available = true
+    root.reflect.notify(['foo'])
+    await vi.advanceTimersByTimeAsync(400)
+    expect(fiber.state).to.equal(FiberState.UNLOADING)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(fiber.state).to.equal(FiberState.LOADING)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+    expect(values).to.deep.equal([1, 1])
+  }))
+
+  it('coalesces duplicate dependency notifications without a transition', async () => {
+    const root = new Context()
+    root.provide('foo', 1)
+    let calls = 0
+    const fiber = root.inject(['foo'], () => { calls += 1 })
+    await fiber
+
+    root.reflect.notify(['foo'])
+    await fiber
+
+    expect(calls).to.equal(1)
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+  })
+
+  it('distinguishes provider incarnations without a global counter', async () => {
+    const root1 = new Context()
+    const root2 = new Context()
+    const values1: number[] = []
+    const values2: number[] = []
+    const dispose1 = root1.provide('foo', 1)
+    root2.provide('foo', 10)
+    const fiber1 = root1.inject(['foo'], ctx => { values1.push(ctx.foo) })
+    const fiber2 = root2.inject(['foo'], ctx => { values2.push(ctx.foo) })
+    await Promise.all([fiber1, fiber2])
+
+    await dispose1()
+    root1.provide('foo', 2)
+    await fiber1
+
+    expect(values1).to.deep.equal([1, 2])
+    expect(values2).to.deep.equal([10])
+    expect(fiber2.state).to.equal(FiberState.ACTIVE)
+  })
+})
+
+describe('Fiber publication ownership', () => {
+  it('resolves dependencies added during publication before activation', async () => {
+    const root = new Context()
+    root.provide('late', {})
+    let calls = 0
+    root.on('internal/plugin', (fiber) => {
+      if (fiber.name === 'target' && fiber.uid !== null) fiber.inject.late = {}
+    })
+
+    const fiber = await root.plugin({
+      name: 'target',
+      apply() { calls += 1 },
+    })
+
+    expect(calls).to.equal(1)
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+  })
+
+  it('rolls back runtime ownership when publication throws', () => {
+    const root = new Context()
+    const plugin = { name: 'broken-publication', apply() {} }
+    root.on('internal/plugin', (fiber) => {
+      if (fiber.name === plugin.name && fiber.uid !== null) throw new Error('publication failed')
+    })
+
+    expect(() => root.plugin(plugin)).to.throw('publication failed')
+    expect(root.registry.has(plugin)).to.be.false
+  })
+
+  it('contains disposal observers, finishes cleanup, and rejects disposal', async () => {
+    const root = new Context()
+    const observed: string[] = []
+    root.on('internal/plugin', (fiber) => {
+      if (fiber.name === 'observed' && fiber.uid === null) throw new Error('observer failed')
+    })
+    root.on('internal/plugin', (fiber) => {
+      if (fiber.name === 'observed' && fiber.uid === null) observed.push('disposed')
+    })
+    const fiber = await root.plugin({ name: 'observed', apply() {} })
+
+    await expect(fiber.dispose()).rejects.toThrow('observer failed')
+    expect(observed).to.deep.equal(['disposed'])
+    expect(fiber.state).to.equal(FiberState.DISPOSED)
+  })
+
+  it('settles disposal observers and cleanup together with stable error order', async () => {
+    const root = new Context()
+    const observerGate = Promise.withResolvers<void>()
+    const cleanupGate = Promise.withResolvers<void>()
+    const observerError = new Error('observer')
+    const cleanupError = new Error('cleanup')
+    let observerStarted = false
+    let cleanupStarted = false
+    root.on('internal/plugin', async (fiber) => {
+      if (fiber.name !== 'async-disposal' || fiber.uid !== null) return
+      observerStarted = true
+      await observerGate.promise
+      throw observerError
+    })
+    const fiber = await root.plugin({
+      name: 'async-disposal',
+      apply() {
+        return async () => {
+          cleanupStarted = true
+          await cleanupGate.promise
+          throw cleanupError
+        }
+      },
+    })
+
+    const disposal = fiber.dispose()
+    await Promise.resolve()
+    expect(observerStarted).to.be.true
+    expect(cleanupStarted).to.be.true
+
+    cleanupGate.resolve()
+    observerGate.resolve()
+    const error = await disposal.catch(error => error)
+    expect(error).to.be.instanceOf(AggregateError)
+    expect(error.errors).to.deep.equal([observerError, cleanupError])
+    expect(fiber.state).to.equal(FiberState.DISPOSED)
+  })
+
+  it('lets parent disposal during publication drain pending child effects', async () => {
+    const root = new Context()
+    let ownerContext!: Context
+    const owner = await root.plugin({
+      name: 'owner',
+      apply(ctx) { ownerContext = ctx },
+    })
+    const cleanupGate = Promise.withResolvers<void>()
+    const cleanupStarted = Promise.withResolvers<void>()
+    let parentDisposal!: Promise<void>
+    let childFiber!: Fiber
+    let childCalls = 0
+
+    root.on('internal/plugin', (fiber) => {
+      if (fiber.name !== 'child' || fiber.uid === null) return
+      childFiber = fiber
+      fiber.ctx.effect(() => async () => {
+        cleanupStarted.resolve()
+        await cleanupGate.promise
+      })
+    })
+    root.on('internal/plugin', (fiber) => {
+      if (fiber.name === 'child' && fiber.uid !== null) parentDisposal = owner.dispose()
+    })
+
+    ownerContext.plugin({
+      name: 'child',
+      apply() { childCalls += 1 },
+    })
+
+    await cleanupStarted.promise
+    let settled = false
+    void parentDisposal.then(() => { settled = true })
+    await Promise.resolve()
+    expect(settled).to.be.false
+
+    cleanupGate.resolve()
+    await parentDisposal
+    expect(childCalls).to.equal(0)
+    expect(childFiber.state).to.equal(FiberState.DISPOSED)
+  })
+
+  it('makes a loading parent join child cleanup already in progress', async () => {
+    const root = new Context()
+    const cleanupGate = Promise.withResolvers<void>()
+    const cleanupStarted = Promise.withResolvers<void>()
+    let ownerFiber!: Fiber
+    let ownerDisposal!: Promise<void>
+    let childDisposal!: Promise<void>
+    let childFiber!: Fiber
+
+    root.on('internal/plugin', (fiber) => {
+      if (fiber.name !== 'loading-child' || fiber.uid === null) return
+      childFiber = fiber
+      fiber.ctx.effect(() => async () => {
+        cleanupStarted.resolve()
+        await cleanupGate.promise
+      })
+      ownerDisposal = ownerFiber.dispose()
+      childDisposal = fiber.dispose()
+    })
+
+    const ownerMount = root.plugin({
+      name: 'loading-owner',
+      apply(ctx) {
+        ownerFiber = ctx.fiber
+        ctx.plugin({ name: 'loading-child', apply() {} })
+      },
+    })
+
+    await cleanupStarted.promise
+    let settled = false
+    void ownerDisposal.then(() => { settled = true })
+    await Promise.resolve()
+    expect(settled).to.be.false
+
+    cleanupGate.resolve()
+    await Promise.all([ownerDisposal, childDisposal, ownerMount])
+    expect(childFiber.state).to.equal(FiberState.DISPOSED)
+    expect(ownerFiber.state).to.equal(FiberState.DISPOSED)
   })
 })


### PR DESCRIPTION
*以下大量LLM内容*
*已包含 #33, #34*

# RFC：可重入安全的 Effect 所有权与 Generation 安全的 Fiber 生命周期

## 1. 摘要

Cordis 使用 Fiber 管理 plugin execution、effect ownership 和 cleanup。`main` 在普通路径上可以工作，但 execution、restart、publication 和 cleanup 相互重入时存在以下问题：

- effect 在 execution 前尚未进入 owner collection，可能逃过 unload；
- public disposer 已启动 cleanup 后，structural owner 无法 join；
- child Fiber 在 parent ownership 建立前发布；
- desired state 经历 `A -> B -> A` 时，旧异步工作可能错误提交；
- execution、public disposal、structural cleanup 与 observer notification 的错误边界不明确。

本 RFC 定义：

1. ownership-before-execution；
2. shared/idempotent public disposal Promise；
3. execution 与 disposal 独立结果通道；
4. cleanup exactly-once、LIFO、attempt-all；
5. public cleanup failure 可观察，structural cleanup failure 记录并 contain；
6. child ownership-before-publication；
7. creation observer fail-fast、disposal observer log-only；
8. desired snapshot 与 generation token 分离；
9. generation 严格串行并防止 ABA；
10. 多 root/module instance 生命周期隔离。

## 2. 问题陈述

### 2.1 Effect ownership 空窗

`main` 原顺序：

```text
执行 effect callback
→ 收集 cleanup
→ 创建 public disposer wrapper
→ 加入 Fiber owner collection
```

execution 内同步调用 `fiber.restart()` 时，restart 可以在 wrapper 注册前取得 unload 快照。之后产生的 cleanup 不属于本轮 unload，restart 会提前达到 quiescence。

### 2.2 Public disposer 与 structural owner 脱节

旧 public disposer 是 single-shot。第一次调用启动 async cleanup 后，第二个 caller 无法取得相同 task。structural owner 因而无法等待已经开始的 cleanup。

### 2.3 Publication 早于 ownership

`internal/plugin` creation listener 可以增加 inject、注册 child effect、dispose parent/child 或同步抛错。如果通知发生在 child disposer 和 parent ownership 建立前，可能产生 orphan runtime 或漏掉 child cleanup。

### 2.4 Desired-state ABA

旧 epoch 由 dependency Fiber uid 拼接。以下序列可能得到相同 epoch：

```text
A 开始 execution
→ desired B
→ desired 再次成为 A
→ 旧 A 恢复并提交
```

snapshot equality 不能标识一次 lifecycle attempt。

### 2.5 错误边界混合

以下结果过去容易被混为一个 Promise：

- effect execution 是否成功；
- direct effect cleanup 是否成功；
- owner 是否已等待 cleanup quiescence；
- Fiber plugin execution 是否成功；
- observer notification 是否成功。

这会造成同一错误重复传播，或让 unrelated cleanup/observer failure 阻止 Fiber 完成 structural transition。

### 2.6 Config validity 与 dependency availability 混合

配置校验失败与依赖缺失是两个独立条件。如果 validation error 只保存在 generation `_error` 中，后续 dependency ready 创建新 token 时可能清除该错误，并以未校验的 `undefined` config 执行 plugin。只有显式提交并成功校验的新配置才能恢复 invalid-config Fiber。

## 3. 范围

### 3.1 目标

- 定义 effect registration、execution、disposal 和 quiescence。
- 支持同步、Promise、iterator 和 async iterator effect。
- 支持 reentrant restart/disposal。
- 定义 public 与 structural cleanup error boundary。
- 定义 child creation/disposal notification 顺序。
- 定义 Fiber desired state、generation 和 stale work。
- 保证 dependency transition 不能清除 config validation failure。
- 保持 lifecycle state 在多个 root/module copy 之间隔离。
- 避免不必要的 helper API 改动。

### 3.2 非目标

- Loader/include 配置事务。
- 修改 `Fiber.update()` 的配置持久化协议。
- 修改 `ctx.on()`、`ctx.once()`、`ctx.provide()` 的公开返回契约。
- 重构通用 EventsService dispatch。
- 强制取消任意用户 Promise。
- 引入全局 scheduler 或 identity allocator。

### 3.3 前置条件

wrapped Fiber 与实际状态 Fiber 的一致性是独立前置修复。本 RFC 假定 lifecycle entry 已解析到实际 Fiber，不再讨论 wrapper canonicalization。(#33)

## 4. 术语

### Effect execution

传给 `ctx.effect(execute)` 的 callback 及其同步/异步/iterator 执行过程。

### Cleanup

Effect execution 或 plugin apply 产生的 resource-release callback。

### Public disposer

`ctx.effect()` 返回的 callable disposer。它是公开 cleanup-result channel。

### Structural owner

持有 effect/child Fiber，并在 unload、restart 或 terminal disposal 中等待其 quiescence 的 Fiber/effect。

### Structural cleanup

owner 为达到 quiescence 而调用 owned disposer 的过程。它会 join public caller 已启动的同一 task，但使用不同的错误传播边界。

### EffectRecord

一次 `ctx.effect()` registration 的 Fiber-local 状态，包含 execution state、cleanup list、public wrapper 和 shared disposal task。

### Impl

一次具体 service provider registration。Impl object identity 表示 provider incarnation。

### EffectRunner

`_execute()` 的适配器，提供 `execute`、`collect`、`epoch` 和 outer stack。Fiber runner 使用 generation token；EffectRecord runner 使用 boolean execution-validity marker。

### Desired snapshot

Fiber 希望达到的 loadability、validated config 和 dependency Impl identity。

### Generation token

一次 lifecycle attempt 的不可复用身份。snapshot 可以相等，但 token 必须不同。

### Inertia

Fiber 当前 load/unload transition 的 Promise。token 表示哪一次 attempt；inertia 表示 transition 何时 settle。

### Quiescence

所有 owned execution 已 settle，所有已收集 cleanup 已完成尝试，且没有仍需 structural owner 等待的 task。

## 5. Lifecycle Boundary Matrix

| 边界 | execution failure | cleanup/observer failure | 对外结果 |
|---|---|---|---|
| sync `ctx.effect(execute)` | 同步 throw | rollback cleanup 由 disposal channel 表达 | execution error 只交付一次 |
| `await effect` | reject execution error | 不属于该 channel | execution result |
| direct `await effect()` | 不重复传播 execution error | reject cleanup error | public cleanup result |
| structural unload/restart | Fiber execution 另行处理 | `logger.error()`，contain | cleanup failure 不 reject owner |
| Fiber plugin execution | `fiber.await()` reject | rollback cleanup 记录并 contain | execution error 决定 FAILED |
| config validation | 同步 ValidationError | dependency change 不清除 | 显式 valid update 后才恢复 |
| `Fiber.update()` | sync hook throw / async hook reject | restart 按 structural 规则处理 | 返回完整 waterfall result |
| terminal `fiber.dispose()` | 已由原 execution channel 交付 | cleanup error 记录并 contain | 达到 DISPOSED 后 resolve |
| creation `internal/plugin` | listener error veto publication | rollback | 同步 fail-fast |
| disposal `internal/plugin` | 不适用 | sync/async error 记录 | 不等待、不 reject disposal |

这张表是本 RFC 的核心 contract。后续章节仅对其展开。

## 6. Effect Contract

### 6.1 Ownership-before-execution

EffectRecord 必须在 execution 进入用户代码前加入 owner collection：

```text
create record
→ register wrapper with owner
→ execute callback
→ collect cleanup
```

因此 reentrant owner transition 能捕获 record。

### 6.2 Execution channel

- sync execution success：`ctx.effect()` 返回 effect handle；
- sync execution failure：`ctx.effect()` 同步 throw；
- async execution success：`await effect` resolve public disposer；
- async execution failure：`await effect` reject execution error；
- execution failure 启动 rollback，但不会写入 disposal result。

### 6.3 Disposal channel

第一次调用 public disposer：

- 使 EffectRecord execution marker inactive；
- 若 execution 尚未 settle，则先等待 execution；
- 执行 cleanup；
- 建立并缓存一个 `Promise<void>`。

后续调用返回同一 Promise，不重复 cleanup。

### 6.4 Cleanup ordering

- 同一个 effect 内 cleanup 按 LIFO 严格串行；
- 一个 cleanup failure 不阻止剩余 cleanup；
- 一个 failure 传播原 Error；多个 failure 使用 AggregateError；
- errors 按逻辑执行顺序排列；
- 用户抛出的 AggregateError 被视为一个 callback failure，不展开。

### 6.5 Structural join

owner 调用同一个 shared disposer Promise，因此必须等待相同 quiescence。

但 structural boundary 会 contain rejection：

```text
await ownedDisposer()
→ rejection: logger.error(error)
→ continue other cleanup
→ continue latest lifecycle target
```

Public caller 仍可从相同 Promise 直接观察 rejection。

### 6.6 Cleanup error reporting

- direct public disposal 不由 Cordis 自动重复记录；调用方获得 rejected Promise；
- structural owner 观察到 rejection 时记录 `logger.error()`；
- Cordis 对同一个 disposal task 的同一个 cleanup failure 最多记录一次；
- async execution 自动 rollback 若无 public observer，cleanup failure 仍必须被记录一次；
- 不使用 process-global error set；reporting state 归属于 EffectRecord。

## 7. Structural Owner Contract

### 7.1 Attempt-all

`_unload()` 必须：

1. 清空 owner snapshot；
2. 调用所有 top-level disposers；
3. 等待所有 disposer settle；
4. 记录每个 cleanup failure；
5. 不因 cleanup failure reject structural transition。

Top-level effect 可以并发 cleanup；每个 effect 内部仍是 LIFO 串行。

### 7.2 Restart

cleanup failure 不写 `_error`，不把 target token 改为 INACTIVE，也不阻止 replacement generation：

```text
old generation unload
→ cleanup failure logged
→ quiescence reached
→ latest loadable token reload
→ ACTIVE
```

如果 replacement execution 自身失败，则由 execution channel 进入 FAILED。

### 7.3 Terminal disposal

terminal disposal 在所有 structural cleanup settle 后进入 DISPOSED。cleanup failure 记录日志，但不使 `Fiber.dispose()` reject。

`DISPOSED` 表示 Fiber 已 terminal 且 owner 不再等待 task，不表示每个 cleanup 都成功释放外部资源。

### 7.4 Fiber execution failure

Fiber plugin execution error仍属于 Fiber lifecycle：

```text
plugin execution fails
→ rollback structural cleanup（cleanup failures logged）
→ Fiber FAILED
→ fiber.await() rejects execution error
```

cleanup error 不与 execution error聚合，也不替换 execution error。

## 8. Fiber Generation Contract

### 8.1 Desired snapshot 与 token 分离

```ts
interface DesiredSnapshot {
  loadable: boolean
  config: any
  implementations: Impl[]
}
```

snapshot 用于 coalescing；opaque token 用于 async work identity。

loadable 同时要求：

- 所有 required dependency 可用；
- 当前配置已经成功校验。

config validation error 独立保存，不属于可由 dependency generation 替换的 execution error。

### 8.2 Token creation

以下情况创建新 token：

- explicit restart；
- accepted config update；
- provider replacement；
- availability transition；
- desired state 从 unavailable 恢复。

无实际 desired change 的重复 notify 可以 coalesce。

### 8.3 ABA

`A(token1) -> B(token2) -> A(token3)` 中，token1 永久 stale。旧 execution 不得提交 ACTIVE、store 或 current error。

### 8.4 Serialization

- generation 严格串行；
- stale execution 已进入用户代码时，必须 settle 并完成 cleanup；
- cleanup failure 被 structural boundary contain；
- quiescence 后启动最新 token；
- stale execution error 可记录，但不污染 current generation。

### 8.5 Fiber state

- unavailable 且无 current execution error：PENDING；
- execution in progress：LOADING；
- current token committed：ACTIVE；
- current execution failure：FAILED；
- structural cleanup in progress：UNLOADING；
- terminal：DISPOSED。

cleanup failure 本身不产生 FAILED。

Config validation failure 也产生 FAILED，但 dependency availability transition 不会清除它。只有 `Fiber.update()` 成功校验并应用新配置后，Fiber 才能创建 loadable generation。

若 valid update 被接受时 dependency 仍不可用，旧 ValidationError 被清除，Fiber 从 FAILED 转为 PENDING；后续 dependency ready 才启动 execution。

## 9. Publication and Observer Contract

### 9.1 Child construction order

```text
create child/context/runner
→ establish parent ownership and child.dispose
→ register runtime/config
→ emit creation internal/plugin while PENDING
→ resolve listener-added inject
→ activate desired generation
```

### 9.2 Creation notification

- 同步 fail-fast；
- 第一个 listener error 停止后续 listener；
- child 在 error 逃逸前 terminalize、移出 runtime 公开路径并启动 rollback；
- parent ownership 保留到 rollback quiescent。

### 9.3 Disposal notification

- observer 是诊断通知，不是 structural owner；
- 调用所有匹配 observer；
- sync throw 通过 logger.error() 报告；
- returned Promise 不被 disposal 等待；
- async rejection 被观察并通过 logger.error() 报告；
- observer failure 不改变 Fiber state 或 disposal result。

## 10. Multiple Roots and Module Copies

- lifecycle state 归属于 Context、Fiber、EffectRecord 或 root-local service store；
- provider incarnation 使用 root-local Impl object identity；
- generation token 由对应 Fiber 创建；
- 一个 root/module copy 的 transition 不影响另一个。

## 11. Compatibility

### Intentional changes

- `ctx.effect()` public disposer 每次返回同一 Promise；
- direct public cleanup failure 可通过该 Promise 观察；
- effect thenable 明确表示 execution result；
- `Fiber.update()` 返回 `internal/update` waterfall result，可等待 async hook 和 restart；
- cleanup attempt-all 可能执行比 main 更多的 callback。

### Preserved behavior

- structural `_unload()` cleanup failure 记录并 contain；
- `Fiber.restart()` 在 cleanup failure 后继续；
- terminal `Fiber.dispose()` 在 cleanup failure 后 resolve；
- `ctx.on()/once()/provide()` 不新增公开返回契约；
- creation notification 保持同步 fail-fast；
- disposal observer failure 仅记录。

## 12. Non-normative Implementation Sketch

### 12.1 EffectRecord

EffectRecord 分别保存：

- execution state/task/error；
- cleanup list；
- shared disposal task；
- owner-list wrapper/removal handle；
- cleanup failure reporting state。

sync execution 不分配 execution Promise；仅在真正发生 reentrant disposal 时懒创建 execution gate。

### 12.2 Fiber runner

Fiber runner epoch 为 opaque object token 或 INACTIVE sentinel。`_refresh()` 比较 DesiredSnapshot 并决定是否创建 token。

Fiber 单独保存 `_configError`。`_refresh()` 在该字段存在时始终生成 unloadable desired state；`Fiber.update()` 只有在 `resolveConfig()` 成功且 update waterfall 进入默认 apply 路径时才清除它。

### 12.3 Serialized transition pump

复用 `_setEpoch/_reload/_unload/inertia`：

- `_setEpoch()` 更新最新 target；
- `_reload()` 在 execution 前后检查 token；
- `_unload()` 等待并 contain cleanup failures；
- cleanup 后根据最新 token进入 PENDING/LOADING/DISPOSED；
- current execution error 单独令 Fiber FAILED。

### 12.4 Error observation

内部自动启动的 lifecycle Promise 会附加 rejection observer 以避免 unhandled rejection，但保留原 Promise 供 `fiber.await()` 观察。

EffectRecord 应保证同一个 cleanup rejection 由 Cordis logger 最多报告一次，无论它先被 auto rollback 还是 structural owner 观察。

`Fiber.update()` 保持普通同步方法以保留 config validation 的同步 throw，但直接返回 waterfall result；默认路径返回 `restart()` Promise。

## 13. Conformance Tests

### Effect execution/disposal

- sync execution failure同步 throw；
- async execution thenable reject；
- execution failure + cleanup success：disposal resolve；
- execution failure + cleanup failure：execution/disposal 分别 reject 对应错误；
- repeated public dispose 返回同一 Promise；
- cleanup LIFO、attempt-all、稳定聚合；
- user AggregateError grouping 保留；
- owner join in-flight public disposal。

### Structural cleanup

- direct public cleanup failure 可观察；
- restart contains cleanup failure、记录一次并进入下一 generation；
- terminal disposal contains cleanup failure并进入 DISPOSED；
- 所有 top-level cleanup 被尝试；
- async auto rollback 与 structural join 不重复记录 cleanup error。

### Generation

- update before initial apply；
- async `internal/update` hook 的 Promise 由 `Fiber.update()` 返回；
- invalid config 在 dependency ready 后仍保持 FAILED 且不执行 plugin；
- explicit valid update 清除 config error；dependency 不可用时进入 PENDING，可用时恢复 execution；
- stale execution error 不污染 current generation；
- provider replacement 使用 Impl identity；
- availability `A -> unavailable -> A`；
- duplicate notification coalescing；
- cleanup failure 不阻止 replacement activation；
- replacement execution failure仍进入 FAILED。

### Publication/observers

- publication listener 增加 inject；
- publication failure rollback；
- parent disposal 等待 PENDING child；
- disposal observer sync failure 记录并继续；
- async observer rejection 被观察但不等待；
- observer failure 不 reject disposal。
