### PR TITLE
fix(core): guard waterfall continuations

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -117,12 +117,18 @@ export class EventsService {
   waterfall(...args: any[]) {
     const [thisArg, callbacks] = this._resolve('waterfall', args)
     const inner = args.pop()
-    const next = () => {
+    const dispatch = () => {
       const callback = callbacks.shift()
-      return callback ? Reflect.apply(callback, thisArg, args) : inner(...args)
+      if (!callback) return inner(...args)
+      let called = false
+      const next = () => {
+        if (called) throw new Error('next() called multiple times')
+        called = true
+        return dispatch()
+      }
+      return Reflect.apply(callback, thisArg, [...args, next])
     }
-    args.push(next)
-    return next()
+    return dispatch()
   }
 
   private register(label: string, name: string | symbol, callback: any, options: EventOptions): () => void {

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -119,7 +119,7 @@ export class EventsService {
     const inner = args.pop()
     const dispatch = () => {
       const callback = callbacks.shift()
-      if (!callback) return inner(...args)
+      if (!callback) return inner()
       let called = false
       const next = () => {
         if (called) throw new Error('next() called multiple times')

--- a/packages/core/tests/events.spec.ts
+++ b/packages/core/tests/events.spec.ts
@@ -214,4 +214,37 @@ describe('Events', () => {
     cb3.mock.resetCalls()
     cb4.mock.resetCalls()
   })
+
+  it('ctx.waterfall() rejects duplicate next()', async () => {
+    const { root } = setup()
+    const terminal = mock.fn(() => 2)
+    const callback = mock.fn<Events['test/waterfall']>((value, next) => {
+      const result = next()
+      expect(() => next()).to.throw('next() called multiple times')
+      return value + result
+    })
+    root.on('test/waterfall', callback)
+
+    expect(root.waterfall('test/waterfall', 1, terminal)).to.equal(3)
+    expect(callback.mock.calls).to.have.length(1)
+    expect(terminal.mock.calls).to.have.length(1)
+  })
+
+  it('ctx.waterfall() supports nested async calls', async () => {
+    const { root } = setup()
+    const terminal = mock.fn(() => 2)
+    const callback = mock.fn(async (value: number, next: () => number) => {
+      await Promise.resolve()
+      const result = next()
+      if (value === 1) {
+        return result + await root.waterfall('test/waterfall', 2, terminal)
+      }
+      return result
+    })
+    root.on('test/waterfall', callback as any)
+
+    expect(await root.waterfall('test/waterfall', 1, terminal)).to.equal(4)
+    expect(callback.mock.calls).to.have.length(2)
+    expect(terminal.mock.calls).to.have.length(2)
+  })
 })

--- a/packages/core/tests/events.spec.ts
+++ b/packages/core/tests/events.spec.ts
@@ -215,35 +215,67 @@ describe('Events', () => {
     cb4.mock.resetCalls()
   })
 
-  it('ctx.waterfall() rejects duplicate next()', async () => {
+  it('ctx.waterfall() rejects duplicate next()', () => {
     const { root } = setup()
     const terminal = mock.fn(() => 2)
     const callback = mock.fn<Events['test/waterfall']>((value, next) => {
-      const result = next()
-      expect(() => next()).to.throw('next() called multiple times')
-      return value + result
+      next()
+      return next()
     })
     root.on('test/waterfall', callback)
 
-    expect(root.waterfall('test/waterfall', 1, terminal)).to.equal(3)
+    expect(() => root.waterfall('test/waterfall', 1, terminal)).to.throw('next() called multiple times')
     expect(callback.mock.calls).to.have.length(1)
+    expect(terminal.mock.calls).to.have.length(1)
+  })
+
+  it('ctx.waterfall() rejects continuations from outer frames', () => {
+    const { root } = setup()
+    const calls: string[] = []
+    let outerNext!: () => number
+    root.on('test/waterfall', (value, next) => {
+      outerNext = next
+      calls.push('first')
+      return next()
+    })
+    root.on('test/waterfall', (value, next) => {
+      calls.push('second')
+      return next()
+    })
+
+    expect(() => root.waterfall('test/waterfall', 1, () => {
+      calls.push('terminal')
+      return outerNext()
+    })).to.throw('next() called multiple times')
+    expect(calls).to.deep.equal(['first', 'second', 'terminal'])
+  })
+
+  it('ctx.waterfall() rejects duplicate next() after awaiting', async () => {
+    const { root } = setup()
+    const terminal = mock.fn(() => 2)
+    root.on('test/async-waterfall', async (value, next) => {
+      const result = await next()
+      expect(() => next()).to.throw('next() called multiple times')
+      return value + result
+    })
+
+    expect(await root.waterfall('test/async-waterfall', 1, terminal)).to.equal(3)
     expect(terminal.mock.calls).to.have.length(1)
   })
 
   it('ctx.waterfall() supports nested async calls', async () => {
     const { root } = setup()
     const terminal = mock.fn(() => 2)
-    const callback = mock.fn(async (value: number, next: () => number) => {
-      await Promise.resolve()
-      const result = next()
+    const callback = mock.fn<Events['test/async-waterfall']>(async (value, next) => {
+      const result = await next()
       if (value === 1) {
-        return result + await root.waterfall('test/waterfall', 2, terminal)
+        return result + await root.waterfall('test/async-waterfall', 2, terminal)
       }
       return result
     })
-    root.on('test/waterfall', callback as any)
+    root.on('test/async-waterfall', callback)
 
-    expect(await root.waterfall('test/waterfall', 1, terminal)).to.equal(4)
+    expect(await root.waterfall('test/async-waterfall', 1, terminal)).to.equal(4)
     expect(callback.mock.calls).to.have.length(2)
     expect(terminal.mock.calls).to.have.length(2)
   })

--- a/packages/core/tests/utils.ts
+++ b/packages/core/tests/utils.ts
@@ -42,6 +42,7 @@ declare module '../src/events' {
   interface Events {
     [event](): void
     'test/waterfall'(value: number, next: () => number): number
+    'test/async-waterfall'(value: number, next: () => number): Promise<number>
     '__proto__'(): void
     'toString'(): void
     'constructor'(): void


### PR DESCRIPTION
Fixes #42.

## Summary

- create a fresh continuation for each waterfall middleware frame
- reject repeated `next()` calls with a deterministic error before they can advance the queue or rerun the terminal
- cover the regression and preserve nested asynchronous waterfall behavior

## Tests

- exact-source smoke test: failed before the fix (`Missing expected exception`) and passes after it
- TypeScript 5.9 transpile syntax check for the changed source and test files
- `git diff --check`
- repository CI (pending)