### PR TITLE
fix(packages): include exported source files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,8 @@
   },
   "files": [
     "lib",
-    "bin.js"
+    "bin.js",
+    "src"
   ],
   "repository": {
     "type": "git",

--- a/packages/core/tests/package.spec.ts
+++ b/packages/core/tests/package.spec.ts
@@ -1,0 +1,25 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { expect, describe, it } from 'vitest'
+
+const execFileAsync = promisify(execFile)
+
+const packages = [
+  ['cordis', 'context.ts'],
+  ['@cordisjs/plugin-loader', 'index.ts'],
+  ['@cordisjs/plugin-timer', 'index.ts'],
+]
+
+describe('Package', () => {
+  it.each(packages)('%s includes exported source files', async (name, source) => {
+    const { stdout } = await execFileAsync(process.env.npm_execpath!, [
+      'workspace',
+      name,
+      'pack',
+      '--dry-run',
+      '--json',
+    ])
+    const files = stdout.trim().split('\n').map(line => JSON.parse(line).location).filter(Boolean)
+    expect(files).to.include(`src/${source}`)
+  })
+})

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -14,7 +14,8 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "author": "Shigma <shigma10826@gmail.com>",
   "license": "MIT",

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -14,7 +14,8 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "author": "Shigma <shigma10826@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

The `cordis`, `@cordisjs/plugin-loader`, and `@cordisjs/plugin-timer` packages expose `./src/*`, but their published file lists omit `src`. As a result, source subpath imports such as `cordis/src/context` resolve through `exports` and then fail with `ERR_MODULE_NOT_FOUND`.

This change includes `src` in all three affected packages and adds a packing regression test that checks the actual Yarn package file lists.

## Verification

- `yarn lint`
- `yarn build core && yarn build`
- `yarn test:json` (20 test files, 166 tests)
- Packed and installed all three packages locally, then imported:
  - `cordis/src/context`
  - `@cordisjs/plugin-loader/src/index`
  - `@cordisjs/plugin-timer/src/index`
