### PR TITLE
fix(include): serialize config writes

### DIFF
--- a/packages/include/src/index.ts
+++ b/packages/include/src/index.ts
@@ -54,6 +54,8 @@ export class Include extends EntryTree {
   private content?: string
   private data?: EntryOptions[]
   private writeTask?: NodeJS.Timeout
+  private pendingWrite?: EntryOptions[]
+  private writeQueue: Promise<void> = Promise.resolve()
 
   constructor(ctx: Context, public config: Include.Config) {
     super(ctx)
@@ -180,8 +182,9 @@ export class Include extends EntryTree {
     await this.root.update(data)
   }
 
-  stop() {
+  async stop() {
     this.root.stop()
+    await this.flushWrite()
   }
 
   async refresh() {
@@ -204,10 +207,28 @@ export class Include extends EntryTree {
 
   private writeFile(config: EntryOptions[]) {
     clearTimeout(this.writeTask)
+    this.pendingWrite = config
     this.writeTask = setTimeout(() => {
-      this.writeTask = undefined
-      this._writeFile(config)
+      this.flushWrite().catch(() => {})
     }, 0)
+  }
+
+  private flushWrite(): Promise<void> {
+    clearTimeout(this.writeTask)
+    this.writeTask = undefined
+    const config = this.pendingWrite
+    this.pendingWrite = undefined
+    if (config === undefined) return this.writeQueue
+    const task = this.writeQueue.then(
+      () => this._writeFile(config),
+      () => this._writeFile(config),
+    )
+    this.writeQueue = task
+    task.catch((error) => {
+      this.ctx.root.logger?.('loader').warn('failed to write config file %C', this.filename)
+      this.ctx.root.logger?.('loader').warn(error)
+    })
+    return task
   }
 
   write() {

--- a/packages/include/tests/write.spec.ts
+++ b/packages/include/tests/write.spec.ts
@@ -1,0 +1,126 @@
+import { Include } from '../src/index.ts'
+import { describe, expect, it, vi } from 'vitest'
+
+function createInclude() {
+  const include = Object.create(Include.prototype) as Include
+  const logger = { warn: vi.fn() }
+  Object.assign(include, {
+    filename: '/tmp/cordis-include-test.yml',
+    writeQueue: Promise.resolve(),
+    ctx: {
+      emit: vi.fn(),
+      root: {
+        logger: () => logger,
+      },
+    },
+    root: {
+      data: [],
+      stop: vi.fn(),
+    },
+  })
+  return { include, logger }
+}
+
+describe('Include writes', () => {
+  it('serializes debounced writes', async () => {
+    const { include } = createInclude()
+    const firstStarted = Promise.withResolvers<void>()
+    const releaseFirst = Promise.withResolvers<void>()
+    const writes: string[] = []
+    let active = 0
+    let maxActive = 0
+
+    ;(include as any)._writeFile = vi.fn(async (config: { id: string }[]) => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      writes.push(config[0].id)
+      if (writes.length === 1) {
+        firstStarted.resolve()
+        await releaseFirst.promise
+      }
+      active -= 1
+    })
+
+    include.root.data = [{ id: 'first', name: 'first' }]
+    include.write()
+    await firstStarted.promise
+
+    include.root.data = [{ id: 'second', name: 'second' }]
+    include.write()
+    await new Promise(resolve => setTimeout(resolve, 10))
+
+    expect(writes).toEqual(['first'])
+    releaseFirst.resolve()
+    await include.stop()
+
+    expect(writes).toEqual(['first', 'second'])
+    expect(maxActive).toBe(1)
+  })
+
+  it('flushes the latest debounced write before stopping', async () => {
+    const { include } = createInclude()
+    const writeStarted = Promise.withResolvers<void>()
+    const releaseWrite = Promise.withResolvers<void>()
+
+    ;(include as any)._writeFile = vi.fn(async () => {
+      writeStarted.resolve()
+      await releaseWrite.promise
+    })
+
+    include.root.data = [{ id: 'pending', name: 'pending' }]
+    include.write()
+
+    let stopped = false
+    const stopTask = include.stop().then(() => { stopped = true })
+    await writeStarted.promise
+    await Promise.resolve()
+
+    expect(stopped).toBe(false)
+    releaseWrite.resolve()
+    await stopTask
+    expect(include.root.stop).toHaveBeenCalledOnce()
+  })
+
+  it('logs asynchronous failures and rethrows them on stop', async () => {
+    const { include, logger } = createInclude()
+    const error = new Error('write failed')
+    const writeStarted = Promise.withResolvers<void>()
+    ;(include as any)._writeFile = vi.fn(async () => {
+      writeStarted.resolve()
+      throw error
+    })
+
+    include.root.data = [{ id: 'failed', name: 'failed' }]
+    include.write()
+    await writeStarted.promise
+    await expect(include.stop()).rejects.toBe(error)
+
+    expect(logger.warn).toHaveBeenCalledWith('failed to write config file %C', '/tmp/cordis-include-test.yml')
+    expect(logger.warn).toHaveBeenCalledWith(error)
+  })
+
+  it('continues writing after a failed attempt', async () => {
+    const { include } = createInclude()
+    const firstStarted = Promise.withResolvers<void>()
+    const error = new Error('write failed')
+    const write = vi.fn()
+      .mockImplementationOnce(async () => {
+        firstStarted.resolve()
+        throw error
+      })
+      .mockResolvedValueOnce(undefined)
+    ;(include as any)._writeFile = write
+
+    include.root.data = [{ id: 'failed', name: 'failed' }]
+    include.write()
+    await firstStarted.promise
+    await Promise.resolve()
+
+    include.root.data = [{ id: 'recovered', name: 'recovered' }]
+    include.write()
+    await include.stop()
+
+    expect(write).toHaveBeenCalledTimes(2)
+    expect(write).toHaveBeenLastCalledWith([{ id: 'recovered', name: 'recovered' }])
+  })
+})


### PR DESCRIPTION
## Summary

- serialize debounced Include config writes
- keep later writes progressing after an earlier failure
- flush the latest pending write during Include teardown
- log asynchronous write failures and surface them from teardown

## Why

Include writes use a shared `<config>.tmp` path. Once one debounced write has started, another `write()` call can start a second `_writeFile()` concurrently. The two operations can race on the temporary file, causing one rename to fail with `ENOENT` and leaving the rejection unobserved. Teardown also returned without waiting for the last pending write.

## Validation

- `yarn lint`
- `yarn build core`
- `yarn build`
- `yarn test:json` — 20 files, 167 tests passed
- real-file reproduction with overlapping public `write()` calls