### PR TITLE
fix(core): reject repeated waterfall next() calls

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -117,12 +117,18 @@ export class EventsService {
   waterfall(...args: any[]) {
     const [thisArg, callbacks] = this._resolve('waterfall', args)
     const inner = args.pop()
-    const next = () => {
+    const dispatch = () => {
       const callback = callbacks.shift()
-      return callback ? Reflect.apply(callback, thisArg, args) : inner(...args)
+      if (!callback) return inner(...args)
+      let called = false
+      const next = () => {
+        if (called) throw new Error('next() called multiple times')
+        called = true
+        return dispatch()
+      }
+      return Reflect.apply(callback, thisArg, [...args, next])
     }
-    args.push(next)
-    return next()
+    return dispatch()
   }
 
   register(label: string, hooks: Hook[], callback: any, options: EventOptions): () => void {

--- a/packages/core/tests/events.spec.ts
+++ b/packages/core/tests/events.spec.ts
@@ -155,4 +155,49 @@ describe('Events', () => {
     cb3.mock.resetCalls()
     cb4.mock.resetCalls()
   })
+
+  it('ctx.waterfall() rejects repeated continuation calls', () => {
+    const { root } = setup()
+    const terminal = mock.fn(() => 2)
+    root.on('test/waterfall', (value, next) => {
+      const result = next()
+      expect(() => next()).to.throw('next() called multiple times')
+      return value + result
+    })
+
+    expect(root.waterfall('test/waterfall', 1, terminal)).to.equal(3)
+    expect(terminal.mock.calls).to.have.length(1)
+  })
+
+  it('ctx.waterfall() rejects repeated continuation calls after awaiting', async () => {
+    const { root } = setup()
+    const terminal = mock.fn(() => 2)
+    root.on('test/waterfall', (async (value: number, next: () => number) => {
+      const result = next()
+      await Promise.resolve()
+      expect(() => next()).to.throw('next() called multiple times')
+      return value + result
+    }) as any)
+
+    expect(await root.waterfall('test/waterfall', 1, terminal)).to.equal(3)
+    expect(terminal.mock.calls).to.have.length(1)
+  })
+
+  it('ctx.waterfall() scopes continuations to nested dispatches', async () => {
+    const { root } = setup()
+    const terminal = mock.fn(() => 2)
+    const callback = mock.fn(async (value: number, next: () => number) => {
+      await Promise.resolve()
+      const result = next()
+      if (value === 1) {
+        return result + await root.waterfall('test/waterfall', 2, terminal)
+      }
+      return result
+    })
+    root.on('test/waterfall', callback as any)
+
+    expect(await root.waterfall('test/waterfall', 1, terminal)).to.equal(4)
+    expect(callback.mock.calls).to.have.length(2)
+    expect(terminal.mock.calls).to.have.length(2)
+  })
 })


### PR DESCRIPTION
Fixes #42.

### Problem

A waterfall middleware can call the same `next()` continuation more than once. Because every middleware currently receives the same queue-advancing function, the second call can reach the exhausted queue and invoke the terminal callback again. That can duplicate non-idempotent terminal work while the waterfall otherwise appears to succeed.

On the affected base, the regression test fails with `Missing expected exception` and the terminal callback is reached twice.

### Change

Give each middleware frame its own continuation and reject a second call from that frame with `next() called multiple times`.

The guard is local to one middleware invocation. Valid synchronous chains retain their ordering and return values, continuations remain guarded across asynchronous suspension, and independently nested waterfall dispatches receive independent state.

### Regression coverage

The added tests verify:

- synchronous continuation reuse throws before repeating terminal work;
- reuse after an `await` is guarded the same way;
- nested asynchronous waterfall dispatches remain independent.

### Validation

- `corepack yarn test core` — 12 files and 74 tests passed
- `corepack yarn test` — 19 files and 166 tests passed
- `corepack yarn yakumo esbuild core && corepack yarn yakumo tsc core` — passed
- `corepack yarn lint` — passed
- `git diff --check` — passed
