### PR TITLE
fix(timer): settle concurrent interval reads in order

### DIFF
--- a/packages/timer/src/index.ts
+++ b/packages/timer/src/index.ts
@@ -63,33 +63,37 @@ export class TimerService extends Service {
       }, 'ctx.interval()')
     } else {
       let done: { kind: 'return'; value: any } | { kind: 'throw'; reason: any } | undefined
-      let nextTask: PromiseWithResolvers<IteratorResult<void>> | undefined
+      const nextTasks: PromiseWithResolvers<IteratorResult<void>>[] = []
       const dispose = this.ctx.effect(() => {
         const timer = setInterval(() => {
-          nextTask?.resolve({ done: false, value: undefined })
+          nextTasks.shift()?.resolve({ done: false, value: undefined })
         }, delay)
         return () => {
           clearInterval(timer)
           if (done) return
           done = { kind: 'throw', reason: new Error('Context has been disposed') }
-          nextTask?.reject(done.reason)
+          for (const task of nextTasks.splice(0)) task.reject(done.reason)
         }
       }, 'ctx.interval()')
       return {
         next: () => {
-          if (!done) return (nextTask = Promise.withResolvers()).promise
+          if (!done) {
+            const task = Promise.withResolvers<IteratorResult<void>>()
+            nextTasks.push(task)
+            return task.promise
+          }
           if (done.kind === 'return') return Promise.resolve({ done: true, value: done.value })
           return Promise.reject(done.reason)
         },
         return: (value) => {
           if (!done) done = { kind: 'return', value }
-          nextTask?.resolve({ done: true, value })
+          for (const task of nextTasks.splice(0)) task.resolve({ done: true, value })
           dispose()
           return Promise.resolve({ done: true, value })
         },
         throw: (reason) => {
           if (!done) done = { kind: 'throw', reason }
-          nextTask?.reject(reason)
+          for (const task of nextTasks.splice(0)) task.reject(reason)
           dispose()
           return Promise.resolve({ done: true, value: undefined })
         },

--- a/packages/timer/tests/index.spec.ts
+++ b/packages/timer/tests/index.spec.ts
@@ -92,6 +92,51 @@ describe('ctx.timer', () => {
       assert.strictEqual(reject.mock.calls.length, 0)
     }))
 
+    it('async iterator (concurrent reads)', withContext(async (ctx) => {
+      const iterator = ctx.interval(1000)
+      const first = iterator.next()
+      const second = iterator.next()
+      const firstResolve = mock.fn()
+      const secondResolve = mock.fn()
+      first.then(firstResolve)
+      second.then(secondResolve)
+
+      await vi.advanceTimersByTimeAsync(1000)
+      assert.strictEqual(firstResolve.mock.calls.length, 1)
+      assert.strictEqual(secondResolve.mock.calls.length, 0)
+
+      await vi.advanceTimersByTimeAsync(1000)
+      assert.strictEqual(firstResolve.mock.calls.length, 1)
+      assert.strictEqual(secondResolve.mock.calls.length, 1)
+      assert.deepStrictEqual(await Promise.all([first, second]), [
+        { done: false, value: undefined },
+        { done: false, value: undefined },
+      ])
+    }))
+
+    it('async iterator (return with concurrent reads)', withContext(async (ctx) => {
+      const iterator = ctx.interval<number>(1000)
+      const reads = [iterator.next(), iterator.next(), iterator.next()]
+
+      assert.deepStrictEqual(await iterator.return!(42), { done: true, value: 42 })
+      assert.deepStrictEqual(await Promise.all(reads), [
+        { done: true, value: 42 },
+        { done: true, value: 42 },
+        { done: true, value: 42 },
+      ])
+      assert.deepStrictEqual(await iterator.next(), { done: true, value: 42 })
+    }))
+
+    it('async iterator (throw with concurrent reads)', withContext(async (ctx) => {
+      const iterator = ctx.interval(1000)
+      const reads = [iterator.next(), iterator.next(), iterator.next()]
+      const reason = new Error('test')
+
+      assert.deepStrictEqual(await iterator.throw!(reason), { done: true, value: undefined })
+      await Promise.all(reads.map(read => assert.rejects(read, reason)))
+      await assert.rejects(iterator.next(), reason)
+    }))
+
     it('async iterator (manual throw)', withContext(async (ctx) => {
       const callback = mock.fn()
       const iterator = ctx.interval(1000)
@@ -185,6 +230,18 @@ describe('ctx.timer', () => {
         assert.strictEqual(callback.mock.calls.length, 2)
         assert.strictEqual(resolve.mock.calls.length, 0)
         assert.strictEqual(reject.mock.calls.length, 1)
+      }
+    }))
+
+    it('async iterator (context dispose with concurrent reads)', withContext(async function* (ctx) {
+      const iterator = ctx.interval(1000)
+      const reads = [iterator.next(), iterator.next(), iterator.next()]
+      ctx.fiber.dispose()
+
+      yield async () => {
+        for (const read of reads) {
+          await assert.rejects(read, { message: 'Context has been disposed' })
+        }
       }
     }))
   })


### PR DESCRIPTION
Fixes #49.

### Problem

The async iterator returned by `ctx.interval(delay)` keeps only one pending resolver. A second `next()` replaces the first, leaving the first promise pending even after later ticks or iterator termination.

| Event | Before | After |
| --- | --- | --- |
| First tick | Resolves the newest read | Resolves the oldest read |
| Later tick | Earlier read remains pending | Resolves the next queued read |
| `return()` | Settles only the newest read | Resolves every queued read as done |
| `throw()` or context disposal | Settles only the newest read | Rejects every queued read |

Ticks with no pending read are still dropped, so the existing interval pulse behavior is unchanged.

### Change

Store pending reads in FIFO order. Each timer tick removes and resolves one request, while terminal paths drain the remaining queue with their existing result or error semantics.

### Regression coverage

The added tests verify:

- two concurrent reads resolve on successive ticks in call order;
- `return()` resolves all queued reads and preserves the terminal value;
- `throw()` rejects all queued reads with the supplied reason;
- context disposal rejects all queued reads with the disposal error.

Each scenario also checks subsequent iterator behavior after termination.

### Validation

- `corepack yarn test timer` — 18 tests passed