### PR TITLE
fix(core): prevent stale Fiber generations from committing

### DIFF
--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -70,6 +70,7 @@ export interface EffectMeta {
 
 interface EffectRunner<T> {
   epoch: T
+  generation?: number
   execute: () => any
   collect: (dispose: Disposable) => void
   getOuterStack: () => string[]
@@ -116,6 +117,7 @@ export class Fiber {
   protected context: Context
 
   private _error: any
+  private _generation = 0
   private _runner: EffectRunner<string>
   private _store: Dict<Impl> = Object.create(null)
 
@@ -228,6 +230,7 @@ export class Fiber {
 
   private _execute<T>(runner: EffectRunner<T>) {
     const oldEpoch = runner.epoch
+    const oldGeneration = runner.generation
     return composeError((info) => {
       const safeCollect = (dispose: void | Disposable) => {
         if (typeof dispose === 'function') {
@@ -260,7 +263,7 @@ export class Fiber {
           await Promise.resolve()
           info.error = new Error()
           while (true) {
-            if (runner.epoch !== oldEpoch) return
+            if (runner.epoch !== oldEpoch || runner.generation !== oldGeneration) return
             const result = await iter.next()
             safeCollect(result.value)
             if (result.done) return
@@ -400,6 +403,8 @@ export class Fiber {
     const oldEpoch = this._runner.epoch
     if (epoch === oldEpoch) return
     this._runner.epoch = epoch
+    this._runner.generation = ++this._generation
+    if (epoch !== INACTIVE) this._error = undefined
     if (this.inertia) return
     this._updateState(() => {
       if (epoch !== INACTIVE && oldEpoch === INACTIVE) {
@@ -415,17 +420,23 @@ export class Fiber {
   private async _reload() {
     this.store = { ...this._store }
     const oldEpoch = this._runner.epoch
+    const oldGeneration = this._runner.generation
     try {
       await Promise.resolve()
-      await this._execute(this._runner)
+      if (this._runner.generation === oldGeneration) {
+        await this._execute(this._runner)
+      }
     } catch (reason) {
-      // impl guarantees that the error is non-null (?)
       this.ctx.logger.error(reason)
-      this._error = reason
-      this._runner.epoch = INACTIVE
+      // Work from a superseded generation may finish and report its failure,
+      // but it must not overwrite the desired state of the current generation.
+      if (this._runner.generation === oldGeneration) {
+        this._error = reason
+        this._runner.epoch = INACTIVE
+      }
     }
     this._updateState(() => {
-      if (this._runner.epoch === oldEpoch) {
+      if (this._runner.epoch === oldEpoch && this._runner.generation === oldGeneration) {
         this.inertia = undefined
       } else {
         this.inertia = this._unload()

--- a/packages/core/tests/fiber.spec.ts
+++ b/packages/core/tests/fiber.spec.ts
@@ -26,7 +26,9 @@ describe('Fiber', () => {
 
   it('inertia lock 2', withTimers(async (root) => {
     const dispose = root.provide('foo', 1)
-    const fiber = root.inject(['foo'], async () => {
+    const values: number[] = []
+    const fiber = root.inject(['foo'], async (ctx) => {
+      values.push(ctx.foo)
       await sleep(1000)
       return () => sleep(1000)
     })
@@ -37,7 +39,12 @@ describe('Fiber', () => {
     expect(fiber.state).to.equal(FiberState.LOADING)
     root.provide('foo', 2)
     await vi.advanceTimersByTimeAsync(400) // 1200
+    expect(fiber.state).to.equal(FiberState.UNLOADING)
+    await vi.advanceTimersByTimeAsync(1000) // 2200
+    expect(fiber.state).to.equal(FiberState.LOADING)
+    await vi.advanceTimersByTimeAsync(1000) // 3200
     expect(fiber.state).to.equal(FiberState.ACTIVE)
+    expect(values).to.deep.equal([1, 2])
   }))
 
   it('inertia lock 3', withTimers(async (root) => {
@@ -179,5 +186,67 @@ describe('Fiber', () => {
     expect(Object.hasOwn(consumer, 'config')).to.equal(false)
     expect(Object.hasOwn(consumer, 'state')).to.equal(false)
     expect(Object.hasOwn(consumer, 'inertia')).to.equal(false)
+  })
+
+  it('does not commit a loading generation after an epoch ABA transition', async () => {
+    const root = new Context()
+    const started = Promise.withResolvers<void>()
+    const release = Promise.withResolvers<void>()
+    const applied: number[] = []
+    const fiber = root.plugin(async (_ctx, config: { value: number }) => {
+      applied.push(config.value)
+      if (config.value === 1) {
+        started.resolve()
+        await release.promise
+      }
+    }, { value: 1 })
+
+    await started.promise
+    fiber.update({ value: 2 })
+    release.resolve()
+    await fiber
+
+    expect(applied).to.deep.equal([1, 2])
+    expect(fiber.config).to.deep.equal({ value: 2 })
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+  })
+
+  it('does not let a stale execution failure poison the current generation', async () => {
+    const root = new Context()
+    const started = Promise.withResolvers<void>()
+    const release = Promise.withResolvers<void>()
+    const applied: number[] = []
+    const fiber = root.plugin(async (_ctx, config: { value: number }) => {
+      applied.push(config.value)
+      if (config.value === 1) {
+        started.resolve()
+        await release.promise
+        throw new Error('stale execution')
+      }
+    }, { value: 1 })
+
+    await started.promise
+    fiber.update({ value: 2 })
+    release.resolve()
+    await fiber
+
+    expect(applied).to.deep.equal([1, 2])
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+  })
+
+  it('clears a failed execution when restart begins a new generation', async () => {
+    const root = new Context()
+    let shouldFail = true
+    const fiber = root.plugin(() => {
+      if (shouldFail) throw new Error('plugin error')
+    })
+
+    await expect(Promise.resolve(fiber)).rejects.toThrow('plugin error')
+    expect(fiber.state).to.equal(FiberState.FAILED)
+
+    shouldFail = false
+    await fiber.restart()
+
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
   })
 })


### PR DESCRIPTION
Fixes #34.

### Problem

A Fiber currently uses its dependency epoch both as the desired-state snapshot and as the identity of in-flight work. If an async plugin load observes `A → B → A`, the original load sees the same epoch when it resumes and is allowed to commit. The Fiber can therefore report `ACTIVE` with a new config or provider even though that generation was never applied.

A related failure occurs after plugin execution rejects: `restart()` successfully runs the plugin again, but the previous execution error remains attached to the Fiber, leaving it in `FAILED`.

```mermaid
stateDiagram-v2
    [*] --> LoadingA: generation 1 / config A
    LoadingA --> DesiredB: update while apply awaits
    DesiredB --> DesiredA2: desired epoch returns to A
    LoadingA --> Unloading: generation 1 settles stale
    Unloading --> LoadingA2: start latest generation
    LoadingA2 --> Active: only generation 3 commits
```

On current `main`, the issue #34 sequence produces:

| Observation | Current `main` | This change |
|---|---:|---:|
| Applied configs | `[1]` | `[1, 2]` |
| Published config | `{ value: 2 }` | `{ value: 2 }` |
| Final state | `ACTIVE` | `ACTIVE` |

The current state is internally inconsistent: config `2` is published without ever running the plugin with config `2`.

### Change

Track a monotonic generation alongside the dependency epoch. Every real desired-state transition receives a fresh generation, even if its epoch string repeats. Reload execution, async-generator collection, error publication, and completion now require both the epoch and generation to remain current.

Starting a loadable generation also clears the previous execution error. A successful explicit restart can therefore recover a failed Fiber, while a failure from superseded work cannot poison the latest generation.

This keeps the existing serialized reload/unload pump and coalesces notifications whose epoch does not change.

### Regression coverage

The tests exercise:

- the exact config `A → B → A` race from #34;
- provider replacement while the previous implementation is still loading;
- a stale execution that rejects after a newer config is requested;
- recovery from `FAILED` through a successful restart.

The ABA and restart tests were also run against `8cc9e33`; they respectively produced `[1]` with published config `2`, and remained `FAILED` with the original error.

### Performance sanity check

A synthetic loop creating, awaiting, and disposing 5,000 synchronous plugins took 932.8 ms on `8cc9e33` and 941.6 ms with this change (single run, Node 22.22.1). This is a smoke check rather than a performance claim; the added counter does not introduce per-effect records or a new scheduler.

### Validation

- `corepack yarn vitest packages/core/tests/fiber.spec.ts --run` — 11 tests passed
- `corepack yarn test` — 19 files and 166 tests passed
- `git diff --check origin/main...HEAD` — passed
