### PR TITLE
fix(core): isolate internal/status observers

### DIFF
--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -100,6 +100,29 @@ export namespace CordisError {
 
 const INACTIVE = '__INACTIVE__'
 
+// invariant: internal/status observers must not own Fiber state or _error
+function dispatchFiberStatus(context: Context, fiber: Fiber, oldState: FiberState) {
+  const args: any[] = ['internal/status', fiber, oldState]
+  let callbacks: Function[]
+  try {
+    callbacks = context.events.dispatch('emit', args)
+  } catch (error) {
+    context.logger.error(error)
+    return
+  }
+
+  for (const callback of callbacks) {
+    try {
+      const result = callback(...args)
+      if (isObject(result) && 'then' in result) {
+        void Promise.resolve(result).catch(error => context.logger.error(error))
+      }
+    } catch (error) {
+      context.logger.error(error)
+    }
+  }
+}
+
 export class Fiber {
   public uid: number | null
   public readonly ctx: Context
@@ -357,7 +380,7 @@ export class Fiber {
     this.state = callback() ?? this._getState()
     if (oldState === this.state) return
     // FIXME internal/fiber-info
-    this.context.emit('internal/status', this, oldState)
+    dispatchFiberStatus(this.context, this, oldState)
 
     // only notify changes between ACTIVE and NON-ACTIVE states
     if (oldState !== FiberState.ACTIVE && this.state !== FiberState.ACTIVE) return

--- a/packages/core/tests/status.spec.ts
+++ b/packages/core/tests/status.spec.ts
@@ -1,0 +1,85 @@
+import { Context, FiberState, Service } from '../src'
+import { expect, describe, it } from 'vitest'
+import { mock } from 'node:test'
+import { sleep } from './utils'
+
+describe('internal/status isolation', () => {
+  it('observer throw does not fail a healthy plugin', async () => {
+    const root = new Context()
+    const error = mock.fn()
+    ;(root.logger as any).error = error
+    root.on('internal/status', () => {
+      throw new Error('observer boom')
+    })
+
+    const fiber = root.plugin(() => {})
+    await fiber
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+    expect(error.mock.calls.length).to.be.greaterThan(0)
+  })
+
+  it('observer throw does not overwrite plugin error', async () => {
+    const root = new Context()
+    const error = mock.fn()
+    ;(root.logger as any).error = error
+    root.on('internal/status', () => {
+      throw new Error('observer boom')
+    })
+
+    const fiber = root.plugin(() => {
+      throw new Error('plugin error')
+    })
+    await expect(fiber).rejects.toThrow('plugin error')
+    expect(fiber.state).to.equal(FiberState.FAILED)
+  })
+
+  it('one throwing observer does not skip later observers', async () => {
+    const root = new Context()
+    ;(root.logger as any).error = mock.fn()
+    const second = mock.fn()
+    root.on('internal/status', () => {
+      throw new Error('observer boom')
+    })
+    root.on('internal/status', second)
+
+    await root.plugin(() => {})
+    expect(second.mock.calls.length).to.be.greaterThan(0)
+  })
+
+  it('observer thenable rejection is contained', async () => {
+    const root = new Context()
+    const error = mock.fn()
+    ;(root.logger as any).error = error
+    root.on('internal/status', () => Promise.reject(new Error('observer boom')))
+
+    const fiber = root.plugin(() => {})
+    await fiber
+    await sleep()
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+    expect(error.mock.calls.length).to.be.greaterThan(0)
+  })
+
+  it('observer throw does not skip service notify', async () => {
+    const root = new Context()
+    ;(root.logger as any).error = mock.fn()
+    root.on('internal/status', () => {
+      throw new Error('observer boom')
+    })
+
+    class Foo extends Service {
+      constructor(ctx: Context) {
+        super(ctx, 'foo')
+      }
+    }
+
+    let applied = false
+    const provider = root.plugin(Foo)
+    const consumer = root.inject(['foo'], () => {
+      applied = true
+    })
+    await provider
+    await consumer
+    expect(applied).to.equal(true)
+    expect(consumer.state).to.equal(FiberState.ACTIVE)
+  })
+})


### PR DESCRIPTION
## Problem

`Fiber._updateState` emits `internal/status` with no isolation. A diagnostic observer that throws is caught by the Fiber constructor, written into `_error`, and can reject `await plugin` even when the plugin itself succeeded. The same throw also:

- overwrites a real plugin execution error, so `FAILED` is attributed to the observer
- aborts remaining `internal/status` listeners
- skips the `reflect.notify` that follows a transition into or out of `ACTIVE`
- turns a later `_reload` emit into an unhandled rejection when nobody awaits the Fiber

`internal/plugin` disposal observers already follow a log-only boundary (see #39). `internal/status` on current `main` does not.

| Observation | Current `main` | This change |
|---|---|---|
| healthy plugin + throwing observer | `await plugin` rejects with the observer error | Fiber stays `ACTIVE`; observer is logged |
| plugin throw + throwing observer | `await plugin` rejects with the observer error | rejects with the plugin error; state is `FAILED` |
| two status observers, first throws | second observer never runs | second observer still runs |
| observer returns a rejected thenable | unhandled rejection | logged; Fiber stays `ACTIVE` |

The five regressions fail on `8cc9e33` for those reasons and pass on this branch.

## Change

Replace the unguarded `emit('internal/status')` with a local `dispatchFiberStatus` helper:

- resolve listeners through the existing `events.dispatch` path so thisArg/bind semantics stay the same
- catch each listener independently and report via `ctx.logger.error`
- observe thenable rejections without awaiting them
- leave `reflect.notify` on the success path after the broadcast

This does not change `internal/plugin`, `internal/dispatch`, or the Fiber generation/epoch machinery in #39 / #54.

## Regression coverage

`packages/core/tests/status.spec.ts` covers the five rows above, including a provider/consumer case so a throwing observer cannot skip service notify.

## Validation

- `yarn lint`
- `yarn yakumo tsc`
- `yarn test cordis/status` — 5 tests passed
- `yarn test cordis` — 13 files, 76 tests passed
- `yarn test:json` — 20 files, 168 tests passed
- `git diff --check origin/main...HEAD` — passed