### PR TITLE
fix(core): dispose internal/update hooks with the fiber

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -55,7 +55,10 @@ export class EventsService {
       if (name === 'internal/update' && !options.global) {
         const hooks = this.fiber._hooks['internal/update'] ??= new DisposableList()
         const method = options.prepend ? 'unshift' : 'push'
-        return hooks[method](listener)
+        return this.fiber.effect(() => {
+          const remove = hooks[method](listener)
+          return remove
+        }, 'ctx.on("internal/update")')
       }
     })
 

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -55,10 +55,7 @@ export class EventsService {
       if (name === 'internal/update' && !options.global) {
         const hooks = this.fiber._hooks['internal/update'] ??= new DisposableList()
         const method = options.prepend ? 'unshift' : 'push'
-        return this.fiber.effect(() => {
-          const remove = hooks[method](listener)
-          return remove
-        }, 'ctx.on("internal/update")')
+        return this.fiber.effect(() => hooks[method](listener), 'ctx.on("internal/update")')
       }
     })
 

--- a/packages/core/tests/update-hooks.spec.ts
+++ b/packages/core/tests/update-hooks.spec.ts
@@ -1,0 +1,70 @@
+import { Context } from '../src'
+import { expect, describe, it } from 'vitest'
+
+describe('internal/update hooks', () => {
+  it('does not accumulate non-global hooks across reloads', async () => {
+    const root = new Context()
+    const calls: number[] = []
+    const fiber = root.plugin((ctx) => {
+      ctx.on('internal/update', (config, _noSave, next) => {
+        calls.push(config.n)
+        return next()
+      })
+    }, { n: 0 })
+
+    await fiber
+    fiber.update({ n: 1 })
+    await fiber
+    fiber.update({ n: 2 })
+    await fiber
+    fiber.update({ n: 3 })
+    await fiber
+
+    expect(calls).to.deep.equal([1, 2, 3])
+  })
+
+  it('explicit dispose stops the hook for the current generation', async () => {
+    const root = new Context()
+    const calls: number[] = []
+    let dispose!: () => void
+    const fiber = root.plugin((ctx) => {
+      dispose = ctx.on('internal/update', (config, _noSave, next) => {
+        calls.push(config.n)
+        return next()
+      })
+    }, { n: 0 })
+
+    await fiber
+    dispose()
+    fiber.update({ n: 1 })
+    await fiber
+    expect(calls).to.deep.equal([])
+  })
+
+  it('global internal/update hooks are not tied to a child fiber reload', async () => {
+    const root = new Context()
+    const globalCalls: number[] = []
+    const localCalls: number[] = []
+
+    root.on('internal/update', (config, _noSave, next) => {
+      globalCalls.push(config.n)
+      return next()
+    }, { global: true })
+
+    const fiber = root.plugin((ctx) => {
+      ctx.on('internal/update', (config, _noSave, next) => {
+        localCalls.push(config.n)
+        return next()
+      })
+    }, { n: 0 })
+
+    await fiber
+    fiber.update({ n: 1 })
+    await fiber
+    fiber.update({ n: 2 })
+    await fiber
+
+    expect(globalCalls).to.deep.equal([1, 2])
+    expect(localCalls).to.deep.equal([1, 2])
+  })
+})


### PR DESCRIPTION
## Problem

Non-global `ctx.on('internal/update')` is intercepted in `EventsService` and stored on `fiber._hooks`, then `on()` returns early so the listener never becomes a fiber effect. `_unload` only clears `_disposables`. The Fiber instance is reused across reloads, so each `fiber.update()` keeps the previous generation's closures.

Three config updates on current `main` therefore dispatch `1 + 2 + 3` listeners:

| Observation | Current `main` | This change |
|---|---|---|
| `update({ n: 1/2/3 })` | `[1, 2, 2, 3, 3, 3]` | `[1, 2, 3]` |
| explicit `dispose()` before update | that generation does not run | unchanged |
| `{ global: true }` listener | not tied to child reload | unchanged |

The accumulation regressions fail on `8cc9e33` with those extra calls and pass on this branch.

## Change

Register the special-cased listener through `fiber.effect`, so `_unload` already drops it. Do not clear `fiber._hooks` and do not touch `_unload` (that path is being rewritten in #39).

This PR is independent of #55 (`internal/status` isolation) and does not change `register()` / `_resolve` (#51).

## Regression coverage

`packages/core/tests/update-hooks.spec.ts` covers accumulation across reloads, explicit dispose of the current generation, and that global `internal/update` hooks are not bound to a child fiber's reload.

## Validation

- `yarn lint`
- `yarn yakumo tsc`
- `yarn test cordis/update-hooks` — 3 tests passed
- `yarn test cordis` — 13 files, 74 tests passed
- `yarn test:json` — 20 files, 166 tests passed
- `git diff --check origin/main...HEAD` — passed