### PR TITLE
fix(include): apply patches on refresh

### DIFF
--- a/packages/include/src/index.ts
+++ b/packages/include/src/index.ts
@@ -54,6 +54,8 @@ export class Include extends EntryTree {
   private content?: string
   private data?: EntryOptions[]
   private writeTask?: NodeJS.Timeout
+  private applying = false
+  private refreshTail: Promise<void> = Promise.resolve()
 
   constructor(ctx: Context, public config: Include.Config) {
     super(ctx)
@@ -134,10 +136,11 @@ export class Include extends EntryTree {
           list = data
         }
         for (const item of insert) {
+          this.ensureId(item)
           const entry = { ...item }
-          if (entry.id ? entryMap.has(entry.id) : list.some(existing => existing.name === entry.name)) continue
+          if (entryMap.has(entry.id) || list.some(existing => existing.name === entry.name)) continue
           list.push(entry)
-          if (entry.id) entryMap.set(entry.id, entry)
+          entryMap.set(entry.id, entry)
         }
         continue
       }
@@ -192,8 +195,21 @@ export class Include extends EntryTree {
   }
 
   async refresh() {
+    const run = this.refreshTail.then(() => this.applyRefresh())
+    this.refreshTail = run.catch(() => {})
+    return run
+  }
+
+  private async applyRefresh() {
     if (!await this.read()) return
-    await this.root.update(this.applyPatches([...this.data!]))
+    clearTimeout(this.writeTask)
+    this.writeTask = undefined
+    this.applying = true
+    try {
+      await this.root.update(this.applyPatches([...this.data!]))
+    } finally {
+      this.applying = false
+    }
   }
 
   private async _writeFile(config: EntryOptions[]) {
@@ -218,6 +234,7 @@ export class Include extends EntryTree {
   }
 
   write() {
+    if (this.applying) return
     this.context.emit('loader/config-update')
     return this.writeFile(this.root.data)
   }

--- a/packages/include/src/index.ts
+++ b/packages/include/src/index.ts
@@ -69,7 +69,8 @@ export class Include extends EntryTree {
 
     ctx.on('internal/update', (config, _, next) => {
       if (config.path !== this.config.path) return next()
-      this.root.update(this.data!)
+      const data = this.applyPatches([...this.data!])
+      return this.root.update(data)
     })
   }
 
@@ -186,7 +187,8 @@ export class Include extends EntryTree {
 
   async refresh() {
     if (!await this.read()) return
-    this.root.update(this.data!)
+    const data = this.applyPatches([...this.data!])
+    await this.root.update(data)
   }
 
   private async _writeFile(config: EntryOptions[]) {

--- a/packages/include/src/index.ts
+++ b/packages/include/src/index.ts
@@ -69,8 +69,7 @@ export class Include extends EntryTree {
 
     ctx.on('internal/update', (config, _, next) => {
       if (config.path !== this.config.path) return next()
-      const data = this.applyPatches([...this.data!])
-      return this.root.update(data)
+      this.root.update(this.data!)
     })
   }
 
@@ -187,8 +186,7 @@ export class Include extends EntryTree {
 
   async refresh() {
     if (!await this.read()) return
-    const data = this.applyPatches([...this.data!])
-    await this.root.update(data)
+    await this.root.update(this.applyPatches([...this.data!]))
   }
 
   private async _writeFile(config: EntryOptions[]) {

--- a/packages/include/src/index.ts
+++ b/packages/include/src/index.ts
@@ -117,6 +117,7 @@ export class Include extends EntryTree {
       const { id, insert, name, ...overrides } = patch
 
       if (insert) {
+        let list: EntryOptions[]
         if (id) {
           const target = entryMap.get(id)
           if (!target) {
@@ -128,9 +129,15 @@ export class Include extends EntryTree {
             continue
           }
           if (!Array.isArray(target.config)) target.config = []
-          target.config.push(...insert)
+          list = target.config
         } else {
-          data.push(...insert)
+          list = data
+        }
+        for (const item of insert) {
+          const entry = { ...item }
+          if (entry.id ? entryMap.has(entry.id) : list.some(existing => existing.name === entry.name)) continue
+          list.push(entry)
+          if (entry.id) entryMap.set(entry.id, entry)
         }
         continue
       }

--- a/packages/include/tests/patch.spec.ts
+++ b/packages/include/tests/patch.spec.ts
@@ -313,4 +313,45 @@ describe('Include patches', () => {
       await unlink(runtime).catch(() => {})
     }
   }, 10000)
+
+  it('should not bake insert patches on a comment-only refresh', async () => {
+    const runtime = new URL('./fixtures/refresh-comment.yml', import.meta.url)
+    const original = await readFile(new URL('./fixtures/base.yml', import.meta.url), 'utf8')
+    await writeFile(runtime, original)
+    try {
+      ctx = new Context()
+      await ctx.plugin(LoggerConsole)
+      fiber = await ctx.plugin(Loader, {
+        baseUrl: import.meta.url,
+      })
+      const id = await ctx.loader.create({
+        name: '@cordisjs/plugin-include',
+        config: {
+          path: './fixtures/refresh-comment.yml',
+          patches: [
+            { insert: [{ name: './extra-plugin' }] },
+          ],
+        },
+      })
+      await ctx.loader.await()
+      const include = ctx.loader.resolve(id).subtree as Include
+      const extras = () => include.root.data.filter(item => String(item.name).includes('extra-plugin'))
+      expect(await readFile(runtime, 'utf8')).to.equal(original)
+      expect(extras()).to.have.length(1)
+      const extraId = extras()[0].id
+
+      await writeFile(runtime, `${original}\n# refreshed\n`)
+      await include.refresh()
+      await ctx.loader.await()
+      await new Promise(r => setTimeout(r, 100))
+      const after = await readFile(runtime, 'utf8')
+      expect(after).to.equal(`${original}\n# refreshed\n`)
+      expect(after).to.not.match(/extra-plugin/)
+      expect(extras()).to.have.length(1)
+      expect(extras()[0].id).to.equal(extraId)
+      expect(ctx.bail('test/get-extra')).to.equal('extra')
+    } finally {
+      await unlink(runtime).catch(() => {})
+    }
+  }, 10000)
 })

--- a/packages/include/tests/patch.spec.ts
+++ b/packages/include/tests/patch.spec.ts
@@ -3,6 +3,7 @@ import Loader from '@cordisjs/plugin-loader'
 import LoggerConsole from '@cordisjs/plugin-logger-console'
 import { expect, describe, it, afterEach } from 'vitest'
 import { readFile, unlink, writeFile } from 'node:fs/promises'
+import Include from '../src/index.ts'
 
 function waitFor(condFn: () => any, timeout = 5000, interval = 100): Promise<void> {
   return new Promise<void>((resolve, reject) => {
@@ -260,14 +261,13 @@ describe('Include patches', () => {
           ],
         },
       })
-      await new Promise(r => setTimeout(r, 1000))
+      await ctx.loader.await()
       expect(ctx.bail('test/get-value')).to.be.undefined
 
       await writeFile(runtime, `${await readFile(runtime, 'utf8')}\n# refreshed\n`)
       const entry = [...ctx.loader.entries()].find(item => item.options.name === '@cordisjs/plugin-include')
-      expect(entry?.subtree).to.be.ok
-      await (entry!.subtree as { refresh(): Promise<void> }).refresh()
-      await new Promise(r => setTimeout(r, 200))
+      await (entry!.subtree as Include).refresh()
+      await ctx.loader.await()
       expect(ctx.bail('test/get-value')).to.be.undefined
     } finally {
       await unlink(runtime).catch(() => {})

--- a/packages/include/tests/patch.spec.ts
+++ b/packages/include/tests/patch.spec.ts
@@ -273,4 +273,44 @@ describe('Include patches', () => {
       await unlink(runtime).catch(() => {})
     }
   }, 10000)
+
+  it('should not duplicate insert patches after a baked refresh', async () => {
+    const runtime = new URL('./fixtures/refresh-insert.yml', import.meta.url)
+    await writeFile(runtime, await readFile(new URL('./fixtures/base.yml', import.meta.url)))
+    try {
+      ctx = new Context()
+      await ctx.plugin(LoggerConsole)
+      fiber = await ctx.plugin(Loader, {
+        baseUrl: import.meta.url,
+      })
+      const id = await ctx.loader.create({
+        name: '@cordisjs/plugin-include',
+        config: {
+          path: './fixtures/refresh-insert.yml',
+          patches: [
+            { insert: [{ name: './extra-plugin' }] },
+          ],
+        },
+      })
+      await ctx.loader.await()
+      const include = ctx.loader.resolve(id).subtree as Include
+      const extras = () => include.root.data.filter(item => String(item.name).includes('extra-plugin'))
+      expect(extras()).to.have.length(1)
+      expect([...ctx.loader.entries()].filter(item => String(item.options.name).includes('extra-plugin'))).to.have.length(1)
+
+      include.write()
+      await new Promise(r => setTimeout(r, 100))
+      const baked = await readFile(runtime, 'utf8')
+      expect(baked).to.match(/extra-plugin/)
+
+      await writeFile(runtime, `${baked}\n# refreshed\n`)
+      await include.refresh()
+      await ctx.loader.await()
+      expect(extras()).to.have.length(1)
+      expect([...ctx.loader.entries()].filter(item => String(item.options.name).includes('extra-plugin'))).to.have.length(1)
+      expect(ctx.bail('test/get-extra')).to.equal('extra')
+    } finally {
+      await unlink(runtime).catch(() => {})
+    }
+  }, 10000)
 })

--- a/packages/include/tests/patch.spec.ts
+++ b/packages/include/tests/patch.spec.ts
@@ -2,6 +2,7 @@ import { Context, Fiber } from 'cordis'
 import Loader from '@cordisjs/plugin-loader'
 import LoggerConsole from '@cordisjs/plugin-logger-console'
 import { expect, describe, it, afterEach } from 'vitest'
+import { readFile, unlink, writeFile } from 'node:fs/promises'
 
 function waitFor(condFn: () => any, timeout = 5000, interval = 100): Promise<void> {
   return new Promise<void>((resolve, reject) => {
@@ -239,5 +240,37 @@ describe('Include patches', () => {
     await new Promise(r => setTimeout(r, 1000))
     // Name matches, so patch should apply and inner should be disabled
     expect(ctx.bail('test/get-value')).to.be.undefined
+  }, 10000)
+
+  it('should keep patches after refresh', async () => {
+    const runtime = new URL('./fixtures/refresh-runtime.yml', import.meta.url)
+    await writeFile(runtime, await readFile(new URL('./fixtures/base.yml', import.meta.url)))
+    try {
+      ctx = new Context()
+      await ctx.plugin(LoggerConsole)
+      fiber = await ctx.plugin(Loader, {
+        baseUrl: import.meta.url,
+      })
+      await ctx.loader.create({
+        name: '@cordisjs/plugin-include',
+        config: {
+          path: './fixtures/refresh-runtime.yml',
+          patches: [
+            { id: 'inner', disabled: true },
+          ],
+        },
+      })
+      await new Promise(r => setTimeout(r, 1000))
+      expect(ctx.bail('test/get-value')).to.be.undefined
+
+      await writeFile(runtime, `${await readFile(runtime, 'utf8')}\n# refreshed\n`)
+      const entry = [...ctx.loader.entries()].find(item => item.options.name === '@cordisjs/plugin-include')
+      expect(entry?.subtree).to.be.ok
+      await (entry!.subtree as { refresh(): Promise<void> }).refresh()
+      await new Promise(r => setTimeout(r, 200))
+      expect(ctx.bail('test/get-value')).to.be.undefined
+    } finally {
+      await unlink(runtime).catch(() => {})
+    }
   }, 10000)
 })


### PR DESCRIPTION
## Problem

`Include[Service.init]` applies `patches` before `root.update()`. `refresh()` feeds `this.data` straight into the tree.

`read()` always replaces `this.data` with the file contents. HMR config reloads call `include.refresh()`, so a `disabled` / config override / insert patch is dropped whenever the file changes and has not been baked back to disk (readonly files never are).

A writable refresh that recreates an insert (new anonymous id) goes through `EntryGroup.remove` → `fiber.dispose()` → `tree.write()` and dumps `root.data` (overlays) over the user's file. The next real edit then double-applies `insert`.

| Path | Current `main` | This change |
|---|---|---|
| `[Service.init]` | `applyPatches` then `await root.update` | insert stamps a stable id; skip if id/name already present |
| `refresh()` after a file change | tree matches the file; patches gone | patches reapplied; `await root.update`; no `write()` |
| same-path `internal/update` | `root.update(this.data)` | unchanged (deferred) |

## Change

Reuse the init sequence in `refresh()`: `await this.root.update(this.applyPatches([...this.data!]))`.

`applyPatches` insert copies each entry after `ensureId` on the patch item, and skips if that id is already in the tree or the target list already has that name.

`refresh()` treats the file as source of truth: overlapping calls are queued, in-flight `writeFile` timers are dropped, and `write()` is ignored until `root.update` returns.

The same-path `internal/update` handler still calls `this.root.update(this.data!)`. Nested `insert` still mutates shared entry objects; that path stays deferred until a clone-then-patch exists.

`writeFile` / `stop` / the debounce queue implementation are otherwise untouched (#47).

## Regression coverage

`packages/include/tests/patch.spec.ts`:

- disable `inner` via patch, rewrite the file, `refresh()`, entry stays disabled
- insert `./extra-plugin`, `write()` bake, rewrite the file, refresh, one extra row
- insert `./extra-plugin`, comment-only rewrite, refresh: file bytes stay the comment (no bake), extra id unchanged

## Validation

- `yarn lint`
- `yarn test include/patch` — 13 tests passed
