### PR TITLE
test(hmr): resolve test fixture paths on Windows

### DIFF
--- a/packages/hmr/tests/index.spec.ts
+++ b/packages/hmr/tests/index.spec.ts
@@ -2,11 +2,11 @@ import { Context, Fiber } from 'cordis'
 import Loader from '@cordisjs/plugin-loader'
 import Logger from '@cordisjs/plugin-logger-console'
 import { writeFileSync, readFileSync, unlinkSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
 import { expect, describe, it, beforeAll, afterAll, afterEach } from 'vitest'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
-const testDir = new URL('.', import.meta.url).pathname
+const testDir = dirname(fileURLToPath(import.meta.url))
 
 // Helper: read and backup a file, returning restore function
 function backupFile(filename: string) {


### PR DESCRIPTION
## Summary

- HMR tests failed to load on Windows because `new URL(...).pathname` is not a filesystem path (`/E:/cordis/...`).
- `path.resolve()` then produced `E:\E:\cordis\...`, so fixture files such as `plugin.ts` could not be opened.
- Resolve the test directory with `dirname(fileURLToPath(import.meta.url))`, which is the Node-standard conversion from `import.meta.url`.

## Test plan

- [x] `yarn yakumo vitest --import tsx hmr` on Windows (Node 24): 26/26 passed
- [x] `yarn test` on Ubuntu (existing CI) still passes