### PR TITLE
ci: audit production dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,23 @@ jobs:
       - name: Lint
         run: yarn lint
 
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install
+        run: yarn --no-immutable
+      - name: Audit production dependencies
+        run: yarn npm audit --all --recursive --environment production
+
   build:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Add a dedicated GitHub Actions job that installs the workspace and runs Yarn's recursive production dependency audit. This catches known vulnerabilities across workspace packages during CI before affected changes are merged or released.