### PR TITLE
chore: correct utilities keyword typo

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/cordiverse/cordis",
   "keywords": [
     "cordis",
-    "utilties"
+    "utilities"
   ],
   "devDependencies": {
     "cordis": "^4.0.0-rc.8"


### PR DESCRIPTION
Corrects the misspelled npm keyword `utilties` to `utilities`