### PR TITLE
fix(core): reject circular plugin dependencies

### DIFF
--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -178,6 +178,7 @@ export class Fiber {
         }
         return async () => {
           this.uid = null
+          this.ctx.registry._release(this)
           this.context.emit('internal/plugin', this)
           if (this.ctx.registry.has(runtime.callback)) {
             remove()
@@ -418,6 +419,7 @@ export class Fiber {
     try {
       await Promise.resolve()
       await this._execute(this._runner)
+      this.ctx.registry.assertProvides(this)
     } catch (reason) {
       // impl guarantees that the error is non-null (?)
       this.ctx.logger.error(reason)

--- a/packages/core/src/reflect.ts
+++ b/packages/core/src/reflect.ts
@@ -187,12 +187,14 @@ export class ReflectService {
       if (this.store[key]) {
         throw new Error(`service "${name}" has been registered at <${this.store[key].fiber.name}>`)
       }
+      const disposeGraph = this.ctx.registry._provide(this.ctx.fiber, name)
       this.store[key] = impl
       this.ctx.fiber.store![name] = impl
       if (this.ctx.fiber.state === FiberState.ACTIVE) {
         this.notify([name])
       }
       return async () => {
+        disposeGraph()
         delete this.store[key]
         const fibers = this.notify([name])
         await Promise.allSettled(fibers.map(fiber => fiber.await()))

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -70,6 +70,7 @@ export namespace Plugin {
     name?: string
     Config?: StandardSchemaV1<any, T>
     inject?: Inject
+    /** Services that every successful fiber of this plugin guarantees to provide. */
     provide?: string | string[]
     intercept?: Dict<boolean>
   }
@@ -96,6 +97,191 @@ export namespace Plugin {
     fibers: DisposableList<Fiber>
     callback: globalThis.Function
     Config?: StandardSchemaV1
+  }
+
+  export interface Meta {
+    inject: Dict<any>
+    provide: string[]
+  }
+
+  export interface Candidate {
+    callback: globalThis.Function
+    parent: Context
+    meta: Meta
+    replace?: Fiber
+    name: string
+  }
+}
+
+declare module './events' {
+  export interface Events {
+    'internal/plugin-meta'(meta: Plugin.Meta): void
+  }
+}
+
+interface DependencyNode {
+  id: object
+  name: string
+  parent: Context
+  inject: string[]
+  provide: string[]
+}
+
+interface ResolvedDependencyNode {
+  id: object
+  name: string
+  inject: Map<symbol, string>
+  provide: Map<symbol, string>
+}
+
+export class CircularDependencyError extends Error {
+  name = 'CircularDependencyError'
+
+  constructor(public cycle: string[]) {
+    super(`circular plugin dependency: ${cycle.join(' -> ')}`)
+  }
+}
+
+class DependencyGraph {
+  private nodes = new Map<Fiber, DependencyNode>()
+  private dynamic = new Map<Fiber, Set<{ ctx: Context, name: string }>>()
+
+  constructor(private registry: RegistryService) {}
+
+  private resolveToken(ctx: Context, name: string) {
+    ctx.root[Context.isolate][name] ??= Symbol(name)
+    return ctx[Context.isolate][name]
+  }
+
+  private createNode(candidate: Plugin.Candidate): DependencyNode {
+    return {
+      id: candidate,
+      name: candidate.name,
+      parent: candidate.parent,
+      inject: Object.keys(candidate.meta.inject),
+      provide: candidate.meta.provide,
+    }
+  }
+
+  private resolveNode(node: DependencyNode): ResolvedDependencyNode {
+    const inject = new Map<symbol, string>()
+    const provide = new Map<symbol, string>()
+    for (const name of node.inject) {
+      inject.set(this.resolveToken(node.parent, name), name)
+    }
+    for (const name of node.provide) {
+      provide.set(this.resolveToken(node.parent, name), name)
+    }
+    return { id: node.id, name: node.name, inject, provide }
+  }
+
+  private collectNodes(candidates: Plugin.Candidate[]) {
+    const replacements = new Set(candidates.map(candidate => candidate.replace).filter(Boolean))
+    const nodes = [...this.nodes]
+      .filter(([fiber]) => !replacements.has(fiber))
+      .map(([fiber, node]) => {
+        const resolved = this.resolveNode(node)
+        for (const entry of this.dynamic.get(fiber) ?? []) {
+          resolved.provide.set(this.resolveToken(entry.ctx, entry.name), entry.name)
+        }
+        return resolved
+      })
+    for (const [fiber, dynamic] of this.dynamic) {
+      if (this.nodes.has(fiber) || replacements.has(fiber)) continue
+      const provide = new Map<symbol, string>()
+      for (const entry of dynamic) {
+        provide.set(this.resolveToken(entry.ctx, entry.name), entry.name)
+      }
+      nodes.push({
+        id: fiber,
+        name: fiber.name,
+        inject: new Map(),
+        provide,
+      })
+    }
+    nodes.push(...candidates.map(candidate => this.resolveNode(this.createNode(candidate))))
+    return nodes
+  }
+
+  validate(candidates: Plugin.Candidate[]) {
+    const nodes = this.collectNodes(candidates)
+    const providers = new Map<symbol, ResolvedDependencyNode>()
+    for (const node of nodes) {
+      for (const [token, name] of node.provide) {
+        const oldNode = providers.get(token)
+        if (oldNode && oldNode.id !== node.id) {
+          throw new Error(`service "${name}" is provided by both <${oldNode.name}> and <${node.name}>`)
+        }
+        providers.set(token, node)
+      }
+    }
+
+    const edges = new Map<ResolvedDependencyNode, ResolvedDependencyNode[]>()
+    for (const node of nodes) {
+      const targets: ResolvedDependencyNode[] = []
+      for (const token of node.inject.keys()) {
+        const target = providers.get(token)
+        if (target) targets.push(target)
+      }
+      edges.set(node, targets)
+    }
+
+    const visited = new Set<ResolvedDependencyNode>()
+    const visiting = new Map<ResolvedDependencyNode, number>()
+    const stack: ResolvedDependencyNode[] = []
+    const visit = (node: ResolvedDependencyNode): void => {
+      if (visited.has(node)) return
+      const index = visiting.get(node)
+      if (index !== undefined) {
+        throw new CircularDependencyError([...stack.slice(index), node].map(node => node.name))
+      }
+      visiting.set(node, stack.length)
+      stack.push(node)
+      for (const target of edges.get(node) ?? []) visit(target)
+      stack.pop()
+      visiting.delete(node)
+      visited.add(node)
+    }
+    for (const node of nodes) visit(node)
+  }
+
+  add(fiber: Fiber, candidate: Plugin.Candidate) {
+    const node = this.createNode(candidate)
+    node.id = fiber
+    this.nodes.set(fiber, node)
+  }
+
+  delete(fiber: Fiber) {
+    this.nodes.delete(fiber)
+    this.dynamic.delete(fiber)
+  }
+
+  provide(fiber: Fiber, ctx: Context, name: string) {
+    const entry = { ctx, name }
+    const dynamic = this.dynamic.get(fiber) ?? new Set<{ ctx: Context, name: string }>()
+    dynamic.add(entry)
+    this.dynamic.set(fiber, dynamic)
+    try {
+      this.validate([])
+    } catch (error) {
+      dynamic.delete(entry)
+      if (!dynamic.size) this.dynamic.delete(fiber)
+      throw error
+    }
+    return () => {
+      dynamic.delete(entry)
+      if (!dynamic.size) this.dynamic.delete(fiber)
+    }
+  }
+
+  assertProvides(fiber: Fiber) {
+    const node = this.nodes.get(fiber)
+    if (!node) return
+    for (const name of node.provide) {
+      const token = this.resolveToken(node.parent, name)
+      if (this.registry.ctx.reflect.store[token]?.fiber === fiber) continue
+      throw new Error(`plugin <${node.name}> declared service "${name}" but did not provide it`)
+    }
   }
 }
 
@@ -125,6 +311,7 @@ declare module './context' {
 export class RegistryService {
   private _counter = 0
   private _internal = new Map<Function, Plugin.Runtime>()
+  private _graph = new DependencyGraph(this)
 
   constructor(public ctx: Context) {
     defineProperty(this, symbols.tracker, {
@@ -190,21 +377,60 @@ export class RegistryService {
     return this.plugin({ inject, apply: callback, name: callback.name })
   }
 
-  plugin(plugin: Plugin, config?: any, getOuterStack = buildOuterStack()) {
-    // check if it's a valid plugin
+  prepare(plugin: Plugin, replace?: Fiber): Plugin.Candidate {
     const callback = this.resolve(plugin)
     if (!callback) throw new Error('invalid plugin, expect function or object with an "apply" method, received ' + typeof plugin)
     this.ctx.fiber.assertActive()
 
+    let name = plugin.name
+    if (name === 'apply') name = undefined
+    const provide = Array.isArray(plugin.provide)
+      ? [...plugin.provide]
+      : plugin.provide ? [plugin.provide] : []
+    const meta: Plugin.Meta = {
+      inject: Inject.resolve(plugin.inject),
+      provide,
+    }
+    this.ctx.emit(this.ctx, 'internal/plugin-meta', meta)
+    return {
+      callback,
+      parent: this.ctx,
+      meta,
+      replace,
+      name: name || callback.name || 'anonymous',
+    }
+  }
+
+  validate(candidates: Plugin.Candidate[]) {
+    this._graph.validate(candidates)
+  }
+
+  assertProvides(fiber: Fiber) {
+    this._graph.assertProvides(fiber)
+  }
+
+  _release(fiber: Fiber) {
+    this._graph.delete(fiber)
+  }
+
+  _provide(fiber: Fiber, name: string) {
+    return this._graph.provide(fiber, this.ctx, name)
+  }
+
+  plugin(plugin: Plugin, config?: any, getOuterStack = buildOuterStack()) {
+    const candidate = this.prepare(plugin)
+    this.validate([candidate])
+    const { callback } = candidate
+
     let runtime = this._internal.get(callback)
     if (!runtime) {
-      let name = plugin.name
-      if (name === 'apply') name = undefined
+      const name = candidate.name === 'anonymous' ? undefined : candidate.name
       runtime = { name, callback, fibers: new DisposableList(), Config: plugin.Config }
       this._internal.set(callback, runtime)
     }
 
-    const fiber = new Fiber(this.ctx, config, Inject.resolve(plugin.inject), runtime, getOuterStack)
+    const fiber = new Fiber(this.ctx, config, candidate.meta.inject, runtime, getOuterStack)
+    this._graph.add(fiber, candidate)
     const wrapped = Object.create(fiber) as Fiber & PromiseLike<Fiber>
     wrapped.then = (onFulfilled, onRejected) => {
       return fiber.await().then(onFulfilled, onRejected)

--- a/packages/core/tests/dependency.spec.ts
+++ b/packages/core/tests/dependency.spec.ts
@@ -1,0 +1,94 @@
+import { CircularDependencyError, Context, FiberState, Service } from '../src'
+import { describe, expect, it } from 'vitest'
+
+describe('Dependency Graph', () => {
+  it('rejects a self dependency', () => {
+    class Self extends Service {
+      static provide = 'self'
+      static inject = ['self']
+
+      constructor(ctx: Context) {
+        super(ctx)
+      }
+    }
+
+    const root = new Context()
+    expect(() => root.plugin(Self)).to.throw(CircularDependencyError)
+  })
+
+  it('rejects an indirect dependency cycle', async () => {
+    class A extends Service {
+      static provide = 'a'
+      static inject = ['b']
+      constructor(ctx: Context) { super(ctx) }
+    }
+
+    class B extends Service {
+      static provide = 'b'
+      static inject = ['c']
+      constructor(ctx: Context) { super(ctx) }
+    }
+
+    class C extends Service {
+      static provide = 'c'
+      static inject = ['a']
+      constructor(ctx: Context) { super(ctx) }
+    }
+
+    const root = new Context()
+    const fiberA = await root.plugin(A)
+    const fiberB = await root.plugin(B)
+    expect(() => root.plugin(C)).to.throw('A -> B -> C -> A')
+    expect(fiberA.state).to.equal(FiberState.PENDING)
+    expect(fiberB.state).to.equal(FiberState.PENDING)
+  })
+
+  it('does not connect services from different isolates', async () => {
+    class A extends Service {
+      static provide = 'a'
+      static inject = ['b']
+      constructor(ctx: Context) { super(ctx) }
+    }
+
+    class B extends Service {
+      static provide = 'b'
+      static inject = ['a']
+      constructor(ctx: Context) { super(ctx) }
+    }
+
+    const root = new Context()
+    const ctxA = root.isolate('a').isolate('b')
+    const ctxB = root.isolate('a').isolate('b')
+    const fiberA = await ctxA.plugin(A)
+    const fiberB = await ctxB.plugin(B)
+    expect(fiberA.state).to.equal(FiberState.PENDING)
+    expect(fiberB.state).to.equal(FiberState.PENDING)
+  })
+
+  it('enforces the static provide contract', async () => {
+    const Broken = Object.assign(function broken() {}, {
+      provide: 'missing',
+    })
+
+    const root = new Context()
+    await expect(root.plugin(Broken)).rejects.toThrow(
+      'plugin <broken> declared service "missing" but did not provide it',
+    )
+  })
+
+  it('tracks dynamic providers until disposal', async () => {
+    class Foo extends Service {
+      static provide = 'foo'
+      constructor(ctx: Context) { super(ctx) }
+    }
+
+    const root = new Context()
+    const dispose = root.provide('foo', {})
+    expect(() => root.plugin(Foo)).to.throw(
+      'service "foo" is provided by both <root> and <Foo>',
+    )
+
+    await dispose()
+    await expect(root.plugin(Foo)).resolves.toBeDefined()
+  })
+})

--- a/packages/core/tests/service.spec.ts
+++ b/packages/core/tests/service.spec.ts
@@ -1,9 +1,45 @@
-import { Context, Service } from '../src'
+import { CircularDependencyError, Context, FiberState, Service } from '../src'
 import { expect, describe, it } from 'vitest'
 import { mock } from 'node:test'
 import { Counter, getHookSnapshot, sleep } from './utils'
 
 describe('Service', () => {
+  it('rejects a statically declared circular dependency', async () => {
+    const startA = mock.fn()
+    const startB = mock.fn()
+
+    class A extends Service {
+      static provide = 'a'
+      static inject = ['b']
+
+      constructor(ctx: Context) {
+        super(ctx)
+        startA()
+      }
+    }
+
+    class B extends Service {
+      static provide = 'b'
+      static inject = ['a']
+
+      constructor(ctx: Context) {
+        super(ctx)
+        startB()
+      }
+    }
+
+    const root = new Context()
+
+    const fiberA = await root.plugin(A)
+    expect(() => root.plugin(B)).to.throw(CircularDependencyError)
+
+    expect(fiberA.state).to.equal(FiberState.PENDING)
+    expect(startA.mock.calls).to.have.length(0)
+    expect(startB.mock.calls).to.have.length(0)
+    expect(root.get('a')).to.be.undefined
+    expect(root.get('b')).to.be.undefined
+  })
+
   it('pending inject', async () => {
     class Foo extends Service {
       constructor(ctx: Context) {

--- a/packages/hmr/src/index.ts
+++ b/packages/hmr/src/index.ts
@@ -328,6 +328,23 @@ class Hmr extends Service {
       return rollback()
     }
 
+    // Validate the whole replacement batch before touching the running fibers.
+    // This keeps the old plugin graph intact when a new static declaration is invalid.
+    try {
+      const candidates: Plugin.Candidate[] = []
+      for (const [, { filename, runtime }] of reloads) {
+        if (!runtime) continue
+        for (const oldFiber of runtime.fibers) {
+          candidates.push(oldFiber.parent.registry.prepare(attempts[filename], oldFiber))
+        }
+      }
+      this.ctx.registry.validate(candidates)
+    } catch (error) {
+      this.ctx.logger.warn('rejected plugin reload during dependency preflight')
+      this.ctx.logger.warn(error)
+      return rollback()
+    }
+
     const reload = (plugin: any, runtime: Plugin.Runtime) => {
       if (!runtime) return
       for (const oldFiber of runtime.fibers) {

--- a/packages/hmr/tests/index.spec.ts
+++ b/packages/hmr/tests/index.spec.ts
@@ -447,10 +447,11 @@ declare module 'cordis' {
 }
 
 class MyService extends Service {
+  static provide = 'myService'
   public data = 'service-v1'
 
   constructor(ctx: Context) {
-    super(ctx, 'myService')
+    super(ctx)
   }
 
   getValue() {
@@ -504,6 +505,17 @@ export default MyService
 
       await waitFor(() => ctx.myService?.getValue() === 'service-v2')
       expect(ctx.myService.getValue()).to.equal('service-v2')
+    }, 10000)
+
+    it('should keep the old plugin when static dependency preflight fails', async () => {
+      const content = readFileSync(pluginPath, 'utf-8')
+      writeFileSync(pluginPath, content.replace(
+        "static provide = 'myService'",
+        "static provide = 'myService'\n  static inject = ['myService']",
+      ))
+
+      await new Promise(r => setTimeout(r, 1500))
+      expect(ctx.myService.getValue()).to.equal('service-v1')
     }, 10000)
   })
 

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -89,8 +89,6 @@ export class Loader extends EntryTree {
       // 1. set `fiber.entry`
       if (fiber.parent[Entry.key] && !fiber.entry) {
         fiber.entry = fiber.parent[Entry.key]
-        // FIXME merge config
-        Inject.resolve(fiber.entry!.options.inject, fiber.inject)
       }
 
       // 2. handle self-dispose
@@ -122,6 +120,12 @@ export class Loader extends EntryTree {
       fiber.entry.options.disabled = true
       fiber.entry.parent.tree.write()
     })
+
+    ctx.on('internal/plugin-meta', function (this: Context, meta) {
+      const entry: Entry | undefined = this[Entry.key]
+      if (!entry) return
+      Inject.resolve(entry.options.inject, meta.inject)
+    }, { global: true })
 
     ctx.plugin(isolate)
   }

--- a/packages/loader/tests/index.spec.ts
+++ b/packages/loader/tests/index.spec.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it, beforeAll } from 'vitest'
-import { Context, FiberState } from 'cordis'
+import { CircularDependencyError, Context, FiberState } from 'cordis'
 import MockLoader, { sleep } from './utils'
 import { Mock } from 'node:test'
 
@@ -147,5 +147,52 @@ describe('Loader: intercept config', () => {
     expect(loader.expectFiber(foo).state).to.equal(FiberState.ACTIVE)
     expect(loader.expectFiber(bar).state).to.equal(FiberState.PENDING)
     expect(loader.expectFiber(qux).state).to.equal(FiberState.ACTIVE)
+  })
+})
+
+describe('Loader: dependency preflight', () => {
+  it('includes entry injects before creating the fiber', async () => {
+    const root = new Context()
+    await root.plugin(MockLoader)
+    const loader = root.loader as MockLoader
+    Object.assign(loader.mock('provider-a', () => {}), { provide: 'a' })
+    Object.assign(loader.mock('provider-b', () => {}), { provide: 'b' })
+
+    const id = await loader.create({
+      name: 'provider-a',
+      inject: ['b'],
+    })
+    expect(loader.expectFiber(id).state).to.equal(FiberState.PENDING)
+
+    await expect(loader.create({
+      name: 'provider-b',
+      inject: ['a'],
+    })).rejects.toBeInstanceOf(CircularDependencyError)
+  })
+
+  it('uses the current isolate mapping after an entry update', async () => {
+    const root = new Context()
+    await root.plugin(MockLoader)
+    const loader = root.loader as MockLoader
+    Object.assign(loader.mock('isolated-a', () => {}), {
+      provide: 'a',
+      inject: ['b'],
+    })
+    Object.assign(loader.mock('root-b', () => {}), {
+      provide: 'b',
+      inject: ['a'],
+    })
+
+    const idA = await loader.create({ name: 'isolated-a' })
+    await loader.update(idA, {
+      isolate: {
+        a: true,
+        b: true,
+      },
+    })
+
+    const idB = await loader.create({ name: 'root-b' })
+    expect(loader.expectFiber(idA).state).to.equal(FiberState.PENDING)
+    expect(loader.expectFiber(idB).state).to.equal(FiberState.PENDING)
   })
 })


### PR DESCRIPTION
## Background

A plugin waits until all services declared in its `inject` metadata are active before it starts.

When plugins depend on each other, none of them can become active. The affected fibers remain in the PENDING state indefinitely, and the dependency cycle is not reported.

The same issue can occur during hot reloads. A replacement plugin may introduce a cycle after the working version has already been unloaded.

## What This PR Changes

Cordis now builds a dependency graph before creating a fiber. If registering a plugin would introduce a dependency cycle, registration is rejected with a `CircularDependencyError` that includes the cycle path.

For example:

```text
plugin-a -> plugin-b -> plugin-c -> plugin-a
```

The registration that completes the cycle is rejected, while previously registered plugins remain unchanged.

The dependency graph also:

- includes dependencies configured through Loader entries;
- distinguishes services with the same name in different isolates;
- checks providers registered dynamically through `ctx.provide()`;
- removes a fiber from the graph when it is disposed.

## Static Provider Declarations

To detect a dependency cycle before startup, a plugin must declare the services it provides through static `provide` metadata.

Static `provide` is now an enforced contract: a fiber that initializes successfully must register every service it declares. If it does not, its initialization fails with an explicit error.

Providers that are created dynamically are checked when `ctx.provide()` is called.

## Hot Reloading

HMR validates the complete replacement batch before unloading the existing fibers.

If a replacement introduces a declared dependency cycle, the reload is rejected and the existing plugin remains active.

## Validation

The following checks passed locally:

- `corepack yarn build`
- `corepack yarn lint`
- `corepack yarn test`
- 20 test files and 172 tests
