### PR TITLE
fix(core): support symbol and prototype-named events

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -43,7 +43,7 @@ export interface Hook extends EventOptions {
 }
 
 export class EventsService {
-  _hooks: Record<keyof any, Hook[]> = {}
+  _hooks: Record<keyof any, Hook[]> = Object.create(null)
 
   constructor(private ctx: Context) {
     defineProperty(this, symbols.tracker, {
@@ -71,8 +71,9 @@ export class EventsService {
 
   private _resolve(type: string, args: any[]) {
     const thisArg = typeof args[0] === 'object' || typeof args[0] === 'function' ? args.shift() : null
-    const name: string = args.shift()
-    if (!name.startsWith('internal/') && this._hooks['internal/dispatch']?.length) {
+    const name: string | symbol = args.shift()
+    const isInternal = typeof name === 'string' && name.startsWith('internal/')
+    if (!isInternal && this._hooks['internal/dispatch']?.length) {
       this.emit('internal/dispatch', type, name, args, thisArg)
     }
     const filter = thisArg?.[Context.filter]
@@ -174,5 +175,5 @@ export interface Events {
   'internal/get'(ctx: Context, name: string, error: Error, next: () => any): any
   'internal/set'(ctx: Context, name: string, value: any, error: Error, next: () => boolean): boolean
   'internal/listener'(this: Context, name: string, listener: any, prepend: boolean): void
-  'internal/dispatch'(mode: DispatchMode, name: string, args: any[], thisArg: any): void
+  'internal/dispatch'(mode: DispatchMode, name: string | symbol, args: any[], thisArg: any): void
 }

--- a/packages/core/tests/events.spec.ts
+++ b/packages/core/tests/events.spec.ts
@@ -1,7 +1,7 @@
 import { Context, Events } from '../src'
 import { expect, describe, it } from 'vitest'
 import { mock } from 'node:test'
-import { event, Filter, Session } from './utils'
+import { event, symbolEvent, Filter, Session } from './utils'
 
 export function createArray<T>(length: number, create: (index: number) => T) {
   return [...new Array(length).keys()].map(create)
@@ -39,6 +39,43 @@ describe('Events', () => {
     dispose()
     root.emit(event)
     expect(callback.mock.calls).to.have.length(1)
+  })
+
+  it('symbol events', async () => {
+    const { root } = setup()
+    const callback = mock.fn()
+    const dispose = root.on(symbolEvent, callback)
+    root.emit(symbolEvent)
+    expect(callback.mock.calls).to.have.length(1)
+    root.emit(symbolEvent)
+    expect(callback.mock.calls).to.have.length(2)
+    dispose()
+    root.emit(symbolEvent)
+    expect(callback.mock.calls).to.have.length(2)
+  })
+
+  it('symbol events dispatch across modes', async () => {
+    const { root } = setup()
+    const callback = mock.fn()
+    root.on(symbolEvent, callback)
+    root.emit(symbolEvent)
+    await root.parallel(symbolEvent)
+    await root.serial(symbolEvent)
+    root.bail(symbolEvent)
+    expect(callback.mock.calls).to.have.length(4)
+  })
+
+  it('prototype-named events', async () => {
+    const { root } = setup()
+    const callback = mock.fn()
+    const dispose = root.on('__proto__', callback)
+    root.emit('__proto__')
+    expect(callback.mock.calls).to.have.length(1)
+    dispose()
+    root.emit('__proto__')
+    expect(callback.mock.calls).to.have.length(1)
+    // the last listener disposal should release the event bucket
+    expect(root.events._hooks['__proto__']).to.have.length(0)
   })
 
   it('ctx.parallel()', async () => {

--- a/packages/core/tests/utils.ts
+++ b/packages/core/tests/utils.ts
@@ -19,6 +19,7 @@ export function sleep(ms = 0) {
 }
 
 export const event = 'custom-event'
+export const symbolEvent = Symbol('symbol-event')
 
 export class Session {
   constructor(public flag: boolean) {}
@@ -41,6 +42,8 @@ export class Filter {
 declare module '../src/events' {
   interface Events {
     [event](): void
+    [symbolEvent](): void
+    '__proto__'(): void
     'test/waterfall'(value: number, next: () => number): number
   }
 }


### PR DESCRIPTION
## Summary

Fixes #50 — symbol and prototype-named events fail during registration or dispatch.

## Problem

The event API accepts symbol names in `ctx.on()`, but dispatching the same symbol throws before its listener can run. A string matching an inherited `Object.prototype` property (e.g. `__proto__`) also fails during registration.

```ts
const ctx = new Context()
const symbol = Symbol('example')
ctx.on(symbol, () => {})
ctx.emit(symbol)
// TypeError: name.startsWith is not a function

ctx.on('__proto__', () => {})
// TypeError: hooks[method] is not a function
```

## Root cause

- `EventsService._hooks` was initialized as a plain object, so `_hooks['__proto__']` resolved to the inherited prototype instead of a listener array.
- `EventsService._resolve()` narrowed every event name to `string` and called `startsWith()` unconditionally, which fails for symbols.

## Fix

- Initialize `_hooks` with `Object.create(null)` so string names never collide with `Object.prototype` members.
- Guard the internal-prefix check in `_resolve()` so it only runs on string names (`typeof name === 'string' && name.startsWith('internal/')`).
- Widen the `internal/dispatch` event name type to `string | symbol`.

## Tests

Added three test cases in `packages/core/tests/events.spec.ts`:

- symbol events register and dispatch via `emit` (and dispose cleanly)
- symbol events dispatch across `emit`/`parallel`/`serial`/`bail`
- `__proto__` registers, dispatches, and releases its bucket on dispose

All 74 core tests pass. The core package builds and type-checks cleanly.
