### PR TITLE
fix: widen optional properties for exactOptionalPropertyTypes

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -11,7 +11,7 @@ export interface Context {
   [symbols.intercept]: Dict
   /** @experimental */
   root: this
-  baseUrl?: string
+  baseUrl?: string | undefined
   events: EventsService
   logger: LoggerService
   reflect: ReflectService

--- a/packages/include/src/index.ts
+++ b/packages/include/src/index.ts
@@ -53,7 +53,7 @@ export class Include extends EntryTree {
   private readonly: boolean
   private content?: string
   private data?: EntryOptions[]
-  private writeTask?: NodeJS.Timeout
+  private writeTask?: NodeJS.Timeout | undefined
 
   constructor(ctx: Context, public config: Include.Config) {
     super(ctx)

--- a/packages/loader/src/config/entry.ts
+++ b/packages/loader/src/config/entry.ts
@@ -42,7 +42,7 @@ export class Entry {
   public subgroup?: EntryGroup
   public subtree?: EntryTree
 
-  _initTask?: Promise<void>
+  _initTask?: Promise<void> | undefined
 
   constructor(public loader: Loader) {
     this.ctx = loader.ctx.extend({ [Entry.key]: this })


### PR DESCRIPTION
# fix: widen optional properties for exactOptionalPropertyTypes compatibility

## Summary

Fixes #65

Under TypeScript's `exactOptionalPropertyTypes` compiler flag, assigning `undefined` to an optional property whose declared type does not explicitly include `undefined` is a type error:

```
Type 'undefined' is not assignable to type 'Timeout'.
```

This is a **type-only change** — no runtime behavior is affected.

## Changes

| File | Property | Before | After |
|------|----------|--------|-------|
| `packages/include/src/index.ts` | `writeTask` | `NodeJS.Timeout` | `NodeJS.Timeout \| undefined` |
| `packages/loader/src/config/entry.ts` | `_initTask` | `Promise<void>` | `Promise<void> \| undefined` |
| `packages/core/src/context.ts` | `baseUrl` | `string` | `string \| undefined` |

## Details

All three properties are already marked optional (`?`) and are explicitly assigned `undefined` at various points in the codebase — so widening the type to include `undefined` is both correct and consistent.

While the original issue only reported `writeTask` in `plugin-include`, the same pattern was present in `plugin-loader` (`_initTask`) and `core` (`baseUrl`). All three are fixed here for consistency.

Consumer projects using `"exactOptionalPropertyTypes": true` in their `tsconfig.json` will no longer hit type errors when importing these packages.

## Testing

No behavior change — this is purely a type annotation fix. The upstream build is unaffected since `exactOptionalPropertyTypes` is not enabled there. Consumer projects with the flag enabled will see the type errors resolved.
