### PR TITLE
fix(utils): capture entry serial in List.push disposer

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -15,8 +15,9 @@ export class List<T> {
 
   push(value: T) {
     this.ctx.effect(() => {
-      this.inner.set(++this.sn, value)
-      return () => this.inner.delete(this.sn)
+      const sn = ++this.sn
+      this.inner.set(sn, value)
+      return () => this.inner.delete(sn)
     }, `${this.trace}.push()`)
   }
 

--- a/packages/utils/tests/index.spec.ts
+++ b/packages/utils/tests/index.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'vitest'
+import { Context } from 'cordis'
+import assert from 'node:assert'
+import { List } from '../src/index.js'
+
+describe('List', () => {
+  it('supports push and iteration', () => {
+    const ctx = new Context()
+    const list = new List(ctx, 'test')
+    list.push('a')
+    list.push('b')
+    assert.strictEqual(list.length, 2)
+    assert.deepStrictEqual([...list], ['a', 'b'])
+  })
+
+  it('does not leak entries across fiber reloads', async () => {
+    const ctx = new Context()
+    let list: List<string> | undefined
+    const fiber = ctx.plugin((sub) => {
+      list ??= new List(sub, 'test')
+      list.push('a')
+      list.push('b')
+    })
+    await fiber
+    assert.deepStrictEqual([...list!], ['a', 'b'])
+    assert.strictEqual(list!.length, 2)
+
+    // Reloading the fiber unloads every pushed entry (its disposer runs) and
+    // then re-runs the plugin callback. Each entry's disposer must remove
+    // exactly the entry it created — otherwise stale entries accumulate.
+    fiber.update({})
+    await fiber
+    assert.deepStrictEqual([...list!], ['a', 'b'])
+    assert.strictEqual(list!.length, 2)
+
+    fiber.update({})
+    await fiber
+    assert.deepStrictEqual([...list!], ['a', 'b'])
+    assert.strictEqual(list!.length, 2)
+  })
+})

--- a/packages/utils/tests/tsconfig.json
+++ b/packages/utils/tests/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.test",
+}


### PR DESCRIPTION
## Problem

`@cordisjs/utils`'s `List.push()` registers an effect whose disposer closes over `this.sn` — the *mutable* field — instead of the serial number of the entry it created:

```ts
push(value: T) {
  this.ctx.effect(() => {
    this.inner.set(++this.sn, value)
    return () => this.inner.delete(this.sn) // reads the *current* sn at dispose time
  }, `${this.trace}.push()`)
}
```

Once a second entry is pushed, `this.sn` has advanced, so disposing the first entry removes the most recent one rather than its own.

This is observable on fiber reload: unloading runs the disposers in reverse order, so the first-pushed entry is never removed and gets re-pushed on the next load. `list.length` grows and iterating yields stale duplicates:

```ts
const ctx = new Context()
let list: List<string>
const fiber = ctx.plugin((sub) => {
  list ??= new List(sub, 'test')
  list.push('a')
  list.push('b')
})
await fiber
console.log([...list], list.length) // ['a','b'] 2

fiber.update({})
await fiber
console.log([...list], list.length) // ['a','a','b'] 3  ← stale entry leaked
```

## Fix

Capture the serial number at push time (matching the core `DisposableList` implementation in `packages/core/src/utils.ts`), so each disposer removes exactly the entry it created:

```ts
push(value: T) {
  this.ctx.effect(() => {
    const sn = ++this.sn
    this.inner.set(sn, value)
    return () => this.inner.delete(sn)
  }, `${this.trace}.push()`)
}
```

## Tests

Added `packages/utils/tests/index.spec.ts` (the `@cordisjs/utils` package previously had no tests) covering:

- basic `push` + iteration/length
- no stale-entry leak across fiber reloads

Verified the regression test fails on `main` (`['a','a','b']`) and passes with the fix. Full suite remains green (165 tests, 20 files).