### PR TITLE
fix(include): initialize missing configs safely

### DIFF
--- a/packages/include/src/index.ts
+++ b/packages/include/src/index.ts
@@ -166,13 +166,13 @@ export class Include extends EntryTree {
   async* [Service.init]() {
     try {
       await this.read()
-    } catch {
-      if (this.config.initial) {
-        this.writeFile(this.config.initial as any)
-        await this.read()
-      } else {
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      if (!this.config.initial) {
         throw new Error(`config file not found: ${this.filename}`)
       }
+      await this._writeFile(this.config.initial as any)
+      await this.read(true)
     }
 
     yield () => this.stop()

--- a/packages/include/tests/initial.spec.ts
+++ b/packages/include/tests/initial.spec.ts
@@ -1,0 +1,50 @@
+import { Context } from 'cordis'
+import Loader from '@cordisjs/plugin-loader'
+import Include from '../src'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+describe('Include initial config', () => {
+  let ctx: Context
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'cordis-include-'))
+    ctx = new Context()
+    await ctx.plugin(Loader)
+  })
+
+  afterEach(async () => {
+    await ctx.fiber.dispose()
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 })
+  })
+
+  it('creates a missing config before startup completes', async () => {
+    const filename = join(tempDir, 'cordis.json')
+    const initial = [{ id: 'foo', name: 'foo', disabled: true }]
+
+    await ctx.plugin(Include, {
+      path: pathToFileURL(filename).href,
+      initial,
+    })
+
+    expect(JSON.parse(await readFile(filename, 'utf8'))).to.deep.equal(initial)
+  })
+
+  it('does not replace a malformed config with the initial value', async () => {
+    const filename = join(tempDir, 'cordis.json')
+    const malformed = '{"plugins": ['
+    await writeFile(filename, malformed)
+
+    await expect(ctx.plugin(Include, {
+      path: pathToFileURL(filename).href,
+      initial: [],
+    })).rejects.toThrow()
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(await readFile(filename, 'utf8')).to.equal(malformed)
+  })
+})


### PR DESCRIPTION
## What this fixes

`initial` is intended to create an Include config when the target file does not exist. The current startup path schedules that write through the normal debounced writer and immediately reads the file again, so first startup can still fail with `ENOENT`.

The same catch block also treats parsing and permission failures as a missing file. If an existing JSON or YAML file is malformed, startup rejects but the scheduled write can still replace the original file with `initial`.

## Root cause

`Service.init` catches every error from the first read, calls the deferred `writeFile()` helper, and then reads again without waiting for the write. This both races missing-file initialization and turns unrelated read failures into destructive recovery attempts.

## Changes

- Only use `initial` when the first read fails with `ENOENT`.
- Await the existing temporary-file-and-rename writer before continuing startup.
- Force the subsequent read so the newly written content is parsed into the in-memory configuration.
- Preserve the original error for malformed or otherwise unreadable existing files.

## Tests

- A missing JSON config is created and fully loaded before plugin startup resolves.
- A malformed existing JSON config rejects startup and remains byte-for-byte unchanged.

Local verification:

- Include workspace: 2 test files, 12 tests passed.
- Full esbuild build and TypeScript declaration build passed.
- ESLint passed.
- The full Vitest run passed 19 test files and 139 tests; the only suite that could not be collected on Windows hit the existing HMR fixture path issue in #58.
