### PR TITLE
fix(loader): persist entry config only after a committed update

### DIFF
--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -72,11 +72,22 @@ export class Loader extends EntryTree {
     ctx.reflect.provide('loader', this, this[Service.check])
 
     ctx.on('internal/update', function (config, noSave, next) {
-      if (!this.entry || noSave || this.parent.fiber?.entry === this.entry) return next()
-      const unparse = this.runtime?.Config?.['simplify']
-      this.entry.options.config = unparse ? unparse(config) : config
-      this.entry.parent.tree.write()
-      return next()
+      const entry = this.entry
+      if (!entry || noSave || this.parent.fiber?.entry === entry) return next()
+      const result: unknown = next()
+      const persist = () => {
+        // invariant: persist only after the chain commits — inner assigned
+        // fiber.config, or a group entry handled the update without next().
+        if (this.config !== config && !entry.options.group) return
+        const unparse = this.runtime?.Config?.['simplify']
+        entry.options.config = unparse ? unparse(config) : config
+        entry.parent.tree.write()
+      }
+      if (result && typeof result === 'object' && 'then' in result) {
+        return Promise.resolve(result).finally(persist)
+      }
+      persist()
+      return result
     }, { global: true, prepend: true })
 
     ctx.on('internal/update', function (config, _, next) {

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -1,4 +1,4 @@
-import { Context, Inject, Service } from 'cordis'
+import { Context, FiberState, Inject, Service } from 'cordis'
 import { defineProperty, Dict, isNullable } from 'cosmokit'
 import { ModuleLoader } from './internal.ts'
 import { Entry, EntryOptions } from './config/entry.ts'
@@ -74,20 +74,31 @@ export class Loader extends EntryTree {
     ctx.on('internal/update', function (config, noSave, next) {
       const entry = this.entry
       if (!entry || noSave || this.parent.fiber?.entry === entry) return next()
-      const result: unknown = next()
+      const previous = this.config
       const persist = () => {
-        // invariant: persist only after the chain commits — inner assigned
-        // fiber.config, or a group entry handled the update without next().
-        if (this.config !== config && !entry.options.group) return
+        // invariant: persist only when this payload was accepted — inner
+        // replaced fiber.config, or Group assigned subgroup.data.
+        if (this.state === FiberState.FAILED) return
+        const innerCommitted = this.config !== previous
+        const groupCommitted = entry.subgroup?.data === config
+        if (!innerCommitted && !groupCommitted) return
         const unparse = this.runtime?.Config?.['simplify']
         entry.options.config = unparse ? unparse(config) : config
         entry.parent.tree.write()
       }
-      if (result && typeof result === 'object' && 'then' in result) {
-        return Promise.resolve(result).finally(persist)
+      try {
+        const result: unknown = next()
+        if (result && typeof result === 'object' && 'then' in result) {
+          // Fiber.update ignores the waterfall return; catch so a failed
+          // restart does not surface as an unhandled rejection from this hook.
+          return Promise.resolve(result).finally(persist).catch(() => {})
+        }
+        persist()
+        return result
+      } catch (error) {
+        persist()
+        throw error
       }
-      persist()
-      return result
     }, { global: true, prepend: true })
 
     ctx.on('internal/update', function (config, _, next) {

--- a/packages/loader/tests/index.spec.ts
+++ b/packages/loader/tests/index.spec.ts
@@ -15,9 +15,9 @@ describe('Loader: basic support', () => {
     await root.plugin(MockLoader)
     loader = root.loader as any
 
-    foo = loader.mock('foo', (ctx: Context) => ctx.on('internal/update', () => {}))
-    bar = loader.mock('bar', (ctx: Context) => ctx.on('internal/update', () => {}))
-    qux = loader.mock('qux', (ctx: Context) => ctx.on('internal/update', () => {}))
+    foo = loader.mock('foo', (ctx: Context) => ctx.on('internal/update', (_config, _noSave, next) => next()))
+    bar = loader.mock('bar', (ctx: Context) => ctx.on('internal/update', (_config, _noSave, next) => next()))
+    qux = loader.mock('qux', (ctx: Context) => ctx.on('internal/update', (_config, _noSave, next) => next()))
   })
 
   it('loader initiate', async () => {

--- a/packages/loader/tests/persist-order.spec.ts
+++ b/packages/loader/tests/persist-order.spec.ts
@@ -1,5 +1,6 @@
 import { expect, describe, it, beforeAll } from 'vitest'
 import { Context, Fiber, FiberState } from 'cordis'
+import { EntryGroup } from '../src'
 import MockLoader, { sleep } from './utils'
 
 function passThrough(ctx: Context) {
@@ -122,6 +123,220 @@ describe('Loader: group update still persists without calling next', () => {
     ])
     expect(loader.data[0].config).to.have.length(2)
     loader.expectEnable(loader.modules.foo)
+  })
+
+  it('still persists when Group runs without the group flag', async () => {
+    await loader.read([{
+      id: 'g',
+      name: '@cordisjs/plugin-group',
+      config: [{ id: '1', name: 'foo' }],
+    }])
+
+    loader.expectFiber('g').update([
+      { id: '1', name: 'foo' },
+      { id: '2', name: 'foo' },
+    ])
+    await sleep()
+
+    expect(loader.store['g']!.options.config).to.deep.equal([
+      { id: '1', name: 'foo' },
+      { id: '2', name: 'foo' },
+    ])
+    expect(loader.data[0].config).to.have.length(2)
+  })
+})
+
+describe('Loader: group intercept veto does not persist', () => {
+  const root = new Context()
+  let loader!: MockLoader
+
+  beforeAll(async () => {
+    await root.plugin(MockLoader)
+    loader = root.loader as any
+    loader.mock('foo', passThrough)
+    const groupish = loader.mock('groupish', (ctx: Context) => {
+      new EntryGroup(ctx, ctx.fiber.entry!.parent.tree)
+      ctx.on('internal/update', () => {})
+    })
+    groupish[EntryGroup.key] = true
+  })
+
+  it('does not persist when a group intercept vetoes before assigning subgroup.data', async () => {
+    // Fiber-local `internal/update` is a DisposableList (push-only), so a
+    // later `{ prepend: true }` cannot run before Group. This plugin
+    // registers the veto first; YAML `group: true` must not persist.
+    await loader.read([{
+      id: 'gv',
+      name: 'groupish',
+      group: true,
+      config: [{ id: '1', name: 'foo' }],
+    }])
+
+    const before = structuredClone(loader.data)
+    loader.expectFiber('gv').update([
+      { id: '1', name: 'foo' },
+      { id: '2', name: 'foo' },
+    ])
+    await sleep()
+
+    expect(loader.store['gv']!.options.config).to.deep.equal([{ id: '1', name: 'foo' }])
+    expect(loader.data).to.deep.equal(before)
+  })
+})
+
+describe('Loader: same-reference veto does not persist', () => {
+  const root = new Context()
+  let loader!: MockLoader
+  let allow = true
+
+  beforeAll(async () => {
+    await root.plugin(MockLoader)
+    loader = root.loader as any
+    loader.mock('foo', (ctx: Context) => {
+      ctx.on('internal/update', (_config, _noSave, next) => {
+        if (allow) return next()
+      })
+    })
+  })
+
+  it('does not write in-place mutations when the update is vetoed', async () => {
+    await loader.read([{ id: '1', name: 'foo' }])
+    loader.expectFiber('1').update({ a: 1 })
+    await sleep()
+
+    allow = false
+    const before = structuredClone(loader.data)
+    const same = loader.expectFiber('1').config
+    same.a = 2
+    loader.expectFiber('1').update(same)
+    await sleep()
+
+    // Prior persist aliases entry.options.config to fiber.config, so in-place
+    // mutation dirties live options. The write snapshot must stay unchanged.
+    expect(loader.data).to.deep.equal(before)
+  })
+})
+
+describe('Loader: failed restart does not persist', () => {
+  const root = new Context()
+  let loader!: MockLoader
+  let booted = false
+
+  beforeAll(async () => {
+    await root.plugin(MockLoader)
+    loader = root.loader as any
+    ;(root.logger as any).error = () => {}
+    loader.mock('foo', (ctx: Context) => {
+      passThrough(ctx)
+      if (booted) throw new Error('reload fail')
+      booted = true
+    })
+  })
+
+  it('leaves persistence unchanged when apply throws on reload', async () => {
+    await loader.read([{ id: '1', name: 'foo' }])
+    const before = structuredClone(loader.data)
+    const writes = loader.writes
+    const fiber = loader.expectFiber('1')
+
+    fiber.update({ a: 3 })
+    await fiber.await().catch(() => {})
+    await sleep()
+
+    expect(fiber.state).to.equal(FiberState.FAILED)
+    expect(loader.writes).to.equal(writes)
+    expect(loader.store['1']!.options.config).to.not.deep.equal({ a: 3 })
+    expect(loader.data).to.deep.equal(before)
+  })
+})
+
+describe('Loader: persist waits for a thenable next()', () => {
+  const root = new Context()
+  let loader!: MockLoader
+  let release!: () => void
+  let gate!: Promise<void>
+
+  beforeAll(async () => {
+    await root.plugin(MockLoader)
+    loader = root.loader as any
+    loader.mock('foo', (ctx: Context) => {
+      ctx.on('internal/update', async (_config, _noSave, next) => {
+        await gate
+        return next()
+      })
+    })
+  })
+
+  it('does not write until a delayed next() settles, then persists the commit', async () => {
+    await loader.read([{ id: '1', name: 'foo' }])
+    gate = new Promise<void>((resolve) => { release = resolve })
+    const writes = loader.writes
+    const before = structuredClone(loader.data)
+
+    loader.expectFiber('1').update({ a: 3 })
+    await sleep()
+
+    expect(loader.writes).to.equal(writes)
+    expect(loader.data).to.deep.equal(before)
+
+    release()
+    await sleep()
+
+    expect(loader.writes).to.equal(writes + 1)
+    expect(loader.data[0].config).to.deep.equal({ a: 3 })
+  })
+})
+
+describe('Loader: persist waits for restart to settle', () => {
+  const root = new Context()
+  let loader!: MockLoader
+
+  beforeAll(async () => {
+    await root.plugin(MockLoader)
+    loader = root.loader as any
+    loader.mock('foo', passThrough)
+  })
+
+  it('leaves persistence unchanged in the same turn as fiber.update()', async () => {
+    await loader.read([{ id: '1', name: 'foo' }])
+    const writes = loader.writes
+    const fiber = loader.expectFiber('1')
+
+    fiber.update({ a: 3 })
+
+    expect(fiber.config).to.deep.equal({ a: 3 })
+    expect(loader.writes).to.equal(writes)
+    expect(loader.data[0].config).to.not.deep.equal({ a: 3 })
+
+    await sleep()
+
+    expect(loader.writes).to.equal(writes + 1)
+    expect(loader.data[0].config).to.deep.equal({ a: 3 })
+  })
+})
+
+describe('Loader: async veto does not persist', () => {
+  const root = new Context()
+  let loader!: MockLoader
+
+  beforeAll(async () => {
+    await root.plugin(MockLoader)
+    loader = root.loader as any
+    loader.mock('foo', (ctx: Context) => {
+      ctx.on('internal/update', async () => {})
+    })
+  })
+
+  it('skips write after a thenable veto settles', async () => {
+    await loader.read([{ id: '1', name: 'foo' }])
+    const writes = loader.writes
+    const before = structuredClone(loader.data)
+
+    loader.expectFiber('1').update({ a: 3 })
+    await sleep()
+
+    expect(loader.writes).to.equal(writes)
+    expect(loader.data).to.deep.equal(before)
   })
 })
 

--- a/packages/loader/tests/persist-order.spec.ts
+++ b/packages/loader/tests/persist-order.spec.ts
@@ -1,0 +1,153 @@
+import { expect, describe, it, beforeAll } from 'vitest'
+import { Context, Fiber, FiberState } from 'cordis'
+import MockLoader, { sleep } from './utils'
+
+function passThrough(ctx: Context) {
+  ctx.on('internal/update', (_config, _noSave, next) => next())
+}
+
+describe('Loader: persist only committed updates', () => {
+  const root = new Context()
+  let loader!: MockLoader
+
+  beforeAll(async () => {
+    await root.plugin(MockLoader)
+    loader = root.loader as any
+    loader.mock('foo', passThrough)
+  })
+
+  it('writes fiber.config, entry.options, and loader.data together', async () => {
+    await loader.read([{ id: '1', name: 'foo' }])
+
+    loader.expectFiber('1').update({ a: 3 })
+    await sleep()
+
+    expect(loader.expectFiber('1').config).to.deep.equal({ a: 3 })
+    expect(loader.store['1']!.options.config).to.deep.equal({ a: 3 })
+    expect(loader.data).to.deep.equal([{
+      id: '1',
+      name: 'foo',
+      config: { a: 3 },
+    }])
+  })
+
+  it('does not persist when noSave skips the writer', async () => {
+    loader.expectFiber('1').update({ a: 9 }, true)
+    await sleep()
+
+    expect(loader.expectFiber('1').config).to.deep.equal({ a: 9 })
+    expect(loader.store['1']!.options.config).to.deep.equal({ a: 3 })
+    expect(loader.data[0].config).to.deep.equal({ a: 3 })
+  })
+})
+
+describe('Loader: vetoed update does not persist', () => {
+  const root = new Context()
+  let loader!: MockLoader
+
+  beforeAll(async () => {
+    await root.plugin(MockLoader)
+    loader = root.loader as any
+    loader.mock('foo', (ctx: Context) => {
+      ctx.on('internal/update', () => {})
+    })
+  })
+
+  it('leaves fiber.config, entry.options, and loader.data unchanged', async () => {
+    await loader.read([{ id: '1', name: 'foo' }])
+    const before = structuredClone(loader.data)
+
+    loader.expectFiber('1').update({ a: 3 })
+    await sleep()
+
+    expect(loader.expectFiber('1').config).to.not.deep.equal({ a: 3 })
+    expect(loader.store['1']!.options.config).to.not.deep.equal({ a: 3 })
+    expect(loader.data).to.deep.equal(before)
+  })
+})
+
+describe('Loader: global veto does not persist', () => {
+  const root = new Context()
+  let loader!: MockLoader
+
+  beforeAll(async () => {
+    await root.plugin(MockLoader)
+    loader = root.loader as any
+    loader.mock('foo', passThrough)
+    root.on('internal/update', function (this: Fiber, config, noSave, next) {
+      if (this.entry?.options.id === '1' && config?.block) return
+      return next()
+    }, { global: true })
+  })
+
+  it('keeps persistence aligned with the skipped inner apply', async () => {
+    await loader.read([{ id: '1', name: 'foo' }])
+
+    loader.expectFiber('1').update({ block: true })
+    await sleep()
+
+    expect(loader.expectFiber('1').config).to.not.deep.equal({ block: true })
+    expect(loader.store['1']!.options.config).to.not.deep.equal({ block: true })
+    expect(loader.data).to.deep.equal([{ id: '1', name: 'foo' }])
+  })
+})
+
+describe('Loader: group update still persists without calling next', () => {
+  const root = new Context()
+  let loader!: MockLoader
+
+  beforeAll(async () => {
+    await root.plugin(MockLoader)
+    loader = root.loader as any
+    loader.mock('foo', passThrough)
+  })
+
+  it('writes the new group config even though Group swallows next()', async () => {
+    await loader.read([{
+      id: 'g',
+      name: '@cordisjs/plugin-group',
+      group: true,
+      config: [{ id: '1', name: 'foo' }],
+    }])
+
+    loader.expectFiber('g').update([
+      { id: '1', name: 'foo' },
+      { id: '2', name: 'foo' },
+    ])
+    await sleep()
+
+    expect(loader.store['g']!.options.config).to.deep.equal([
+      { id: '1', name: 'foo' },
+      { id: '2', name: 'foo' },
+    ])
+    expect(loader.data[0].config).to.have.length(2)
+    loader.expectEnable(loader.modules.foo)
+  })
+})
+
+describe('Loader: child dispose does not disable the entry', () => {
+  const root = new Context()
+  let loader!: MockLoader
+  let child!: Fiber
+
+  beforeAll(async () => {
+    await root.plugin(MockLoader)
+    loader = root.loader as any
+    loader.mock('foo', (ctx: Context) => {
+      passThrough(ctx)
+      child = ctx.plugin(() => {})
+    })
+  })
+
+  it('keeps the parent entry enabled after a nested fiber dispose', async () => {
+    await loader.read([{ id: '1', name: 'foo' }])
+    expect(loader.expectFiber('1').state).to.equal(FiberState.ACTIVE)
+
+    await child.dispose()
+    await sleep()
+
+    expect(loader.expectFiber('1').state).to.equal(FiberState.ACTIVE)
+    expect(loader.store['1']!.options.disabled).to.not.be.ok
+    expect(loader.data).to.deep.equal([{ id: '1', name: 'foo' }])
+  })
+})

--- a/packages/loader/tests/utils.ts
+++ b/packages/loader/tests/utils.ts
@@ -15,6 +15,7 @@ declare module '../src' {
 
 export default class MockLoader extends Loader {
   public data: EntryOptions[] = []
+  public writes = 0
   public modules: Dict<Plugin.Object> = Object.create(null)
 
   constructor(ctx: Context) {
@@ -28,13 +29,14 @@ export default class MockLoader extends Loader {
   }
 
   write() {
-    this.data = this.root.data
+    this.writes++
+    this.data = structuredClone(this.root.data)
   }
 
   async read(data: any) {
-    this.data = data
     await this.root.update(data)
     await this.await()
+    this.write()
   }
 
   async import(name: string) {


### PR DESCRIPTION
## Frame

Cordis today is a **declarative lifecycle + dependency-graph kernel with cooperative composability**: plugins declare effects, and correctness of unload depends on those plugins (or the host APIs they used) supplying inverses. Host-mediated paths (`ctx.timeout` / `ctx.interval`, `ctx.on`, `ctx.provide`) already invert themselves. Bare `setInterval` / sockets / files do not. This PR does **not** claim that unload clears those, and it does **not** turn Core into a capability or resource-ownership kernel.

That split is the useful one for later work:

| Layer | Question | This PR |
|---|---|---|
| Outer | Can the runtime own side effects so correctness does not depend on plugin-authored inverses? | No. Research only. |
| Inner | Even when every plugin cooperates, is **Desired → Committed → Persistence** honest? | Yes. Loader persistence only. |

**Desired** is the payload someone asked for (`fiber.update(config)`). **Committed** is the payload the runtime actually accepted (inner assigned a new `fiber.config`, or Group assigned `subgroup.data`). **Persistence** is what `tree.write()` will later round-trip as the graph.

Today those three are implicit. Inner assigns `fiber.config` *then* `restart()` (`packages/core/src/fiber.ts`). Persistence used to run *before* `next()`, so a veto could write Desired while runtime stayed on the old object. This PR makes one local invariant true:

> Only a committed entry transition may hit Loader persistence.

Cite this PR for later inner-layer work (Include same-path intercept, HMR mixed generation, a first-class Reconcile / Desired≠Committed model). Do not cite it as effect-ownership being closed — that remains disposer tracking, not resource ownership.

## Problem

The persist hook on `internal/update` wrote `entry.options.config` and called `tree.write()` **before** `next()`. An empty fiber-local hook is a waterfall veto. Runtime then kept the old config; disk/in-memory persistence already had the new one.

Group is a second, real commit path: `@cordisjs/plugin-group` swallows `next()` and runs `EntryGroup.update`. That is not a veto, so Group still has to persist — but the YAML `group: true` flag is not “Group intercept ran.”

`cordisjs/cordis#19` (child `ctx.plugin()` + `dispose()` must not disable the parent entry) already holds on current `main` via `internal/plugin` case 3. This PR only locks it; it does not retouch that hook (`#66` occupies the later inject-meta edit).

## Change

Persist after `next()` (and after a thenable settles). Then write only if the payload was accepted:

- ordinary plugin: `this.config !== previous`, where `previous` is snapshotted **before** `next()` (inner assigned a new reference)
- Group: `entry.subgroup?.data === config` (`EntryGroup.update` assigns `this.data = config` synchronously) — **not** YAML `group: true`
- failed apply: `this.state === FiberState.FAILED` skips the write (inner may already have assigned `fiber.config`)
- `noSave` and child-fiber updates still skip the writer

Same-path Include intercept also swallows `next()` and has no Group signal. This PR treats that as non-commit and **does not edit Include** (`#47` / `#57` / `#74` already occupy that file). Old persist-before-`next()` wrote Include plugin config even when Include ignored the new object; stopping that write is intentional.

Tests: `packages/loader/tests/persist-order.spec.ts`. MockLoader `write()` snapshots with `structuredClone` and counts calls, so `loader.data` is not an alias of live `root.data`. Empty `internal/update` hooks in `index.spec.ts` now call `next()` (an empty hook is a veto; the old self-update tests were documenting persist-before-veto).

## Test plan

- [ ] `yarn test loader` — ordinary commit, local/global/async veto, Group with and without YAML `group`, Group-shaped intercept veto, same-reference veto, FAILED restart, delayed `next()`, same-turn `fiber.update` does not write yet, `noSave`, child dispose (#19 lock)
- [ ] veto a group-flagged entry: persistence stays old
- [ ] Group plugin **without** `group: true`: persistence still updates when intercept assigns `subgroup.data`
- [ ] plugin apply throws on reload: `FiberState.FAILED`, `tree.write` not called
- [ ] `yarn test include` still green (no Include source change)

## Out of scope

- `events.ts` / `fiber.ts` / Include implementation
- HMR mixed-generation reload (`#66` inserts into `partialReload`)
- SES / capability / an ownership ledger in Core
- claiming `Fiber.effect` tracking means unload owns the real world