### PR TITLE
fix(timer): settle concurrent interval reads in order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,136 @@
+# Contributing to Cordis
+
+Thanks for your interest in contributing! This document covers how to get started
+with development, and what is expected when you open a pull request.
+
+## Repository overview
+
+Cordis is a TypeScript monorepo managed with [Yarn 4](https://yarnpkg.com/) workspaces
+and [yakumo](https://github.com/yakumojs/yakumo). It contains the following packages
+under `packages/`:
+
+- `core` — the framework runtime
+- `create` — scaffolding for new projects
+- `group` — group model utilities
+- `hmr` — hot module reloading support
+- `include` — config file inclusion
+- `loader` — plugin loading
+- `logger-console` — console log formatting
+- `timer` — timer model utilities
+- `utils` — shared utilities
+
+There are also external workspaces under `external/`.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 24 or newer (CI runs on Node 24 and 26)
+- [Corepack](https://github.com/nodejs/corepack) enabled, so that the pinned Yarn
+  version in `package.json` is used automatically
+- Git
+
+## Setting up the development environment
+
+1. Fork the repository on GitHub, then clone your fork:
+
+   ```sh
+   git clone git@github.com:<your-username>/cordis.git
+   cd cordis
+   git remote add upstream git@github.com:cordiverse/cordis.git
+   ```
+
+2. Install dependencies:
+
+   ```sh
+   corepack enable
+   yarn
+   ```
+
+## Common commands
+
+Run everything from the repository root:
+
+| Command       | Description                                              |
+| ------------- | -------------------------------------------------------- |
+| `yarn lint`      | Lint the codebase with ESLint                          |
+| `yarn build`     | Build all packages (esbuild, then type check with tsc) |
+| `yarn test`      | Run the test suite with Vitest                         |
+| `yarn test:text` | Run tests with a text coverage report                  |
+| `yarn test:html` | Run tests with an HTML coverage report                 |
+
+To run commands for a single package, prefix the command with
+`yarn yakumo` and append the workspace name, for example:
+
+```sh
+yarn yakumo vitest --import tsx core
+```
+
+## Making changes
+
+1. Base your work on the latest `main`:
+
+   ```sh
+   git fetch upstream
+   git checkout -b <branch-name> upstream/main
+   ```
+
+2. Make your changes. Keep them focused: one logical change per pull request.
+3. Add tests for any behavior change. Tests live in `packages/<package>/tests/`
+   and are written with Vitest.
+4. Run the checks locally before pushing:
+
+   ```sh
+   yarn lint
+   yarn build
+   yarn test
+   ```
+
+5. Commit your changes and push to your fork:
+
+   ```sh
+   git push -u origin <branch-name>
+   ```
+
+6. Open a pull request against `cordiverse/cordis:main`. If your change addresses
+   an issue, reference it in the PR description (e.g. "Closes #123").
+
+## Commit message conventions
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+- Use a type prefix: `feat`, `fix`, `perf`, `refactor`, `chore`, `docs`, `test`, etc.
+- Scope the message to the package you changed, e.g. `fix(core): ...`,
+  `feat(loader): ...`, `chore: ...` for repository-wide changes.
+- Keep the subject line under 72 characters, starting with a lowercase letter.
+
+Examples from the repository history:
+
+```text
+fix(core): track direct service callers
+feat(loader): use internal loader without `--expose-internals`
+perf(core): avoid binding callbacks in event dispatch
+chore: bump versions
+```
+
+## Code style
+
+- The project uses the `@cordisjs/eslint-config` preset; run `yarn lint` before
+  pushing.
+- TypeScript is compiled in strict mode; type errors fail the CI build.
+- Do not introduce new runtime dependencies without discussing them first.
+
+## CI
+
+The [build workflow](.github/workflows/build.yml) runs three jobs on every pull
+request:
+
+- `lint` — ESLint
+- `build` — esbuild bundling and `tsc` type checking
+- `test` — the full Vitest suite on Node 24 and 26
+
+All of them must pass before a pull request can be merged. You can reproduce them
+locally with `yarn lint`, `yarn build`, and `yarn test`.
+
+## Questions
+
+If you are not sure whether a change is wanted, open an issue first to discuss it.
+The issue tracker is also the right place to report bugs and request features.

--- a/packages/timer/src/index.ts
+++ b/packages/timer/src/index.ts
@@ -63,33 +63,40 @@ export class TimerService extends Service {
       }, 'ctx.interval()')
     } else {
       let done: { kind: 'return'; value: any } | { kind: 'throw'; reason: any } | undefined
-      let nextTask: PromiseWithResolvers<IteratorResult<void>> | undefined
+      const pending: PromiseWithResolvers<IteratorResult<void>>[] = []
       const dispose = this.ctx.effect(() => {
         const timer = setInterval(() => {
-          nextTask?.resolve({ done: false, value: undefined })
+          pending.shift()?.resolve({ done: false, value: undefined })
         }, delay)
         return () => {
           clearInterval(timer)
           if (done) return
           done = { kind: 'throw', reason: new Error('Context has been disposed') }
-          nextTask?.reject(done.reason)
+          for (const task of pending) task.reject(done.reason)
+          pending.length = 0
         }
       }, 'ctx.interval()')
       return {
         next: () => {
-          if (!done) return (nextTask = Promise.withResolvers()).promise
-          if (done.kind === 'return') return Promise.resolve({ done: true, value: done.value })
-          return Promise.reject(done.reason)
+          if (done) {
+            if (done.kind === 'return') return Promise.resolve({ done: true, value: done.value })
+            return Promise.reject(done.reason)
+          }
+          const task = Promise.withResolvers<IteratorResult<void>>()
+          pending.push(task)
+          return task.promise
         },
         return: (value) => {
           if (!done) done = { kind: 'return', value }
-          nextTask?.resolve({ done: true, value })
+          for (const task of pending) task.resolve({ done: true, value })
+          pending.length = 0
           dispose()
           return Promise.resolve({ done: true, value })
         },
         throw: (reason) => {
           if (!done) done = { kind: 'throw', reason }
-          nextTask?.reject(reason)
+          for (const task of pending) task.reject(reason)
+          pending.length = 0
           dispose()
           return Promise.resolve({ done: true, value: undefined })
         },

--- a/packages/timer/tests/index.spec.ts
+++ b/packages/timer/tests/index.spec.ts
@@ -187,6 +187,52 @@ describe('ctx.timer', () => {
         assert.strictEqual(reject.mock.calls.length, 1)
       }
     }))
+
+    it('async iterator (concurrent reads settle in order)', withContext(async (ctx) => {
+      const iterator = ctx.interval(1000)
+      const first = iterator.next()
+      const second = iterator.next()
+      const settled: boolean[] = []
+      first.then(() => settled.push(true), () => settled.push(true))
+      second.then(() => settled.push(true), () => settled.push(true))
+      await vi.advanceTimersByTimeAsync(1000)
+      assert.strictEqual(settled.length, 1)
+      assert.deepStrictEqual(await first, { done: false, value: undefined })
+      assert.strictEqual(settled.length, 1)
+      await vi.advanceTimersByTimeAsync(1000)
+      assert.strictEqual(settled.length, 2)
+      assert.deepStrictEqual(await second, { done: false, value: undefined })
+    }))
+
+    it('async iterator (return settles concurrent reads)', withContext(async (ctx) => {
+      const iterator = ctx.interval(1000)
+      const first = iterator.next()
+      const second = iterator.next()
+      await iterator.return!(42)
+      assert.deepStrictEqual(await first, { done: true, value: 42 })
+      assert.deepStrictEqual(await second, { done: true, value: 42 })
+    }))
+
+    it('async iterator (throw rejects concurrent reads)', withContext(async (ctx) => {
+      const iterator = ctx.interval(1000)
+      const first = iterator.next()
+      const second = iterator.next()
+      const reason = new Error('test')
+      await iterator.throw!(reason)
+      await assert.rejects(first, reason)
+      await assert.rejects(second, reason)
+    }))
+
+    it('async iterator (context dispose rejects concurrent reads)', withContext(async function* (ctx) {
+      const iterator = ctx.interval(1000)
+      const first = iterator.next()
+      const second = iterator.next()
+      ctx.fiber.dispose()
+      yield async () => {
+        await assert.rejects(first, /Context has been disposed/)
+        await assert.rejects(second, /Context has been disposed/)
+      }
+    }))
   })
 
   describe('ctx.throttle()', () => {


### PR DESCRIPTION
Closes #49

## Problem

The async iterator returned by `ctx.interval(delay)` stored a single pending
resolver. Each `next()` overwrote it, so:

- a timer tick could only settle the most recent read;
- earlier concurrent reads stayed pending forever;
- `return()`, `throw()`, and context disposal could only settle the latest read.

## Fix

Replace the single resolver with a FIFO queue of pending reads:

- each timer tick resolves the oldest pending read;
- `return()` resolves every remaining read as `done`;
- `throw()` rejects every remaining read with the supplied reason;
- context disposal rejects every remaining read with the disposal error;
- ticks received while no read is pending are still dropped (pulse behavior preserved).

## Tests

Added 4 tests covering: ordered settlement of concurrent reads, `return()`
settling all pending reads, `throw()` rejecting all pending reads, and context
disposal rejecting all pending reads.

Verified locally: `yarn lint`, `yarn build`, `yarn test` (167 passed).