### PR TITLE
fix(hmr): allow watch-only mode without loader internals

### DIFF
--- a/packages/hmr/src/index.ts
+++ b/packages/hmr/src/index.ts
@@ -32,7 +32,7 @@ async function loadDependencies(job: ModuleJob, ignored = new Set<string>()) {
   const dependencies = new Set<string>()
   async function traverse(job: ModuleJob) {
     if (ignored.has(job.url) || dependencies.has(job.url)) return
-    if (job.url.startsWith('node:') || job.url.includes('/node_modules/')) return
+    if (isBuiltinOrExternal(job.url)) return
     dependencies.add(job.url)
     const children = await job.linked
     await Promise.all(Array.prototype.map.call(children, traverse))
@@ -40,6 +40,13 @@ async function loadDependencies(job: ModuleJob, ignored = new Set<string>()) {
   await traverse(job)
   return dependencies
 }
+
+/** True for Node builtins (`node:` scheme) and node_modules dependencies — not user code for HMR. */
+function isBuiltinOrExternal(url: string): boolean {
+  return url.startsWith('node:') || url.includes('/node_modules/')
+}
+
+const LOADER_INTERNALS_ERROR = 'HMR module reload requires loader internals: run with --expose-internals (Node process flag) or use watch-only mode (root: [])'
 
 /** An entry plugin whose module has changed. Keyed by the *old* plugin. */
 interface StalePlugin {
@@ -81,8 +88,13 @@ function hasInactiveAncestor(fiber: Fiber) {
 class Hmr extends Service {
   public baseDir: string
 
-  private internal: ModuleLoader
-  private watcher!: FSWatcher
+  private internal: ModuleLoader | undefined
+  private watcher?: FSWatcher
+
+  /** Non-null accessor: the constructor guarantees `internal` when `root.length > 0`. */
+  private get requiredInternal(): ModuleLoader {
+    return this.internal!
+  }
 
   /**
    * Changes from externals will always trigger a full reload.
@@ -107,8 +119,8 @@ class Hmr extends Service {
 
   constructor(ctx: Context, public config: Hmr.Config) {
     super(ctx, 'hmr')
-    if (!this.ctx.loader.internal) {
-      throw new Error('--expose-internals is required for HMR service')
+    if (this.config.root.length && !this.ctx.loader.internal) {
+      throw new Error(LOADER_INTERNALS_ERROR)
     }
     this.internal = this.ctx.loader.internal
     this.baseDir = fileURLToPath(new URL(config.base || '.', ctx.baseUrl))
@@ -118,9 +130,11 @@ class Hmr extends Service {
    * Resolve a module specifier to a URL, compatible with Node 22-24.
    */
   private async _resolve(specifier: string, parentURL: string, attrs: ImportAttributes): Promise<ResolveResult> {
-    switch (this.internal.version) {
-      case 'v1': return await this.internal.resolve(specifier, parentURL, attrs)
-      case 'v2': return this.internal.resolveSync(parentURL, { specifier, attributes: attrs })
+    const version = this.requiredInternal.version
+    switch (version) {
+      case 'v1': return await this.requiredInternal.resolve(specifier, parentURL, attrs)
+      case 'v2': return this.requiredInternal.resolveSync(parentURL, { specifier, attributes: attrs })
+      default: throw new Error(`unsupported loader internal version: ${String(version)}`)
     }
   }
 
@@ -135,51 +149,52 @@ class Hmr extends Service {
       this.ctx.logger.info('watching %o in %s', root, this.baseDir)
     }
 
-    const match = picomatch(ignored)
-    this.watcher = watch(root, {
-      ...this.config,
-      cwd: this.baseDir,
-      ignored: path => match(relative(this.baseDir, path)),
-    })
+    this.externals = new Set()
 
-    // Collect externals: framework modules reachable from the main entry.
-    // Changes to these files require a full process restart, not HMR.
-    const mainUrl = pathToFileURL(resolve(process.argv[1])).href
-    const mainJob = this.internal.loadCache.get(mainUrl)
-    if (mainJob) {
-      this.externals = await loadDependencies(mainJob)
-    } else {
-      this.externals = new Set()
+    // In watch-only mode (root: []) there is nothing to watch or track.
+    if (this.config.root.length) {
+      const match = picomatch(ignored)
+      this.watcher = watch(root, {
+        ...this.config,
+        cwd: this.baseDir,
+        ignored: path => match(relative(this.baseDir, path)),
+      })
+
+      // Collect externals: framework modules reachable from the main entry.
+      // Changes to these files require a full process restart, not HMR.
+      const mainUrl = pathToFileURL(resolve(process.argv[1])).href
+      const mainJob = this.requiredInternal.loadCache.get(mainUrl)
+      if (mainJob) this.externals = await loadDependencies(mainJob)
+
+      const partialReload = this.ctx.debounce(() => this.partialReload(), this.config.debounce)
+
+      this.watcher.on('change', async (path) => {
+        this.ctx.logger.debug('change detected at %C', path)
+        const filename = resolve(this.baseDir, path)
+        const url = pathToFileURL(filename).href
+
+        // Full reload: the changed file is part of the framework
+        if (this.externals.has(url)) return loader.exit()
+
+        // Partial reload: the file is in the ESM loadCache
+        // In Node 24, both CJS and ESM modules imported via import() end up
+        // in loadCache, so this check covers all module formats.
+        if (this.requiredInternal.loadCache.has(url)) {
+          this.stashed.add(url)
+          return partialReload()
+        }
+
+        // Config reload: the file is a loader config file (e.g. cordis.yml)
+        for (const entry of this.ctx.loader.entries()) {
+          const include = entry.subtree as Include | undefined
+          if (include?.filename !== filename) continue
+          await include.refresh()
+          return
+        }
+
+        this.ctx.emit('hmr/change', url)
+      })
     }
-
-    const partialReload = this.ctx.debounce(() => this.partialReload(), this.config.debounce)
-
-    this.watcher.on('change', async (path) => {
-      this.ctx.logger.debug('change detected at %C', path)
-      const filename = resolve(this.baseDir, path)
-      const url = pathToFileURL(filename).href
-
-      // Full reload: the changed file is part of the framework
-      if (this.externals.has(url)) return loader.exit()
-
-      // Partial reload: the file is in the ESM loadCache
-      // In Node 24, both CJS and ESM modules imported via import() end up
-      // in loadCache, so this check covers all module formats.
-      if (loader.internal!.loadCache.has(url)) {
-        this.stashed.add(url)
-        return partialReload()
-      }
-
-      // Config reload: the file is a loader config file (e.g. cordis.yml)
-      for (const entry of this.ctx.loader.entries()) {
-        const include = entry.subtree as Include | undefined
-        if (include?.filename !== filename) continue
-        await include.refresh()
-        return
-      }
-
-      this.ctx.emit('hmr/change', url)
-    })
   }
 
   // hide stack trace from HMR
@@ -188,7 +203,7 @@ class Hmr extends Service {
   ]
 
   async getLinked(url: string) {
-    const job = this.internal.loadCache.get(url)
+    const job = this.internal?.loadCache.get(url)
     if (!job) return []
     const linked = await job.linked
     return Array.prototype.map.call(linked, (job: ModuleJob) => job.url) as string[]
@@ -207,7 +222,7 @@ class Hmr extends Service {
     this.accepted = new Set(this.stashed)
     this.declined = new Set(this.externals)
 
-    const isExcluded = (url: string) => url.startsWith('node:') || url.includes('/node_modules/')
+    const isExcluded = isBuiltinOrExternal
 
     await Promise.all([...this.stashed].map(async (url) => {
       const children = await this.getLinked(url)
@@ -258,6 +273,7 @@ class Hmr extends Service {
 
   private async partialReload() {
     await this.analyzeChanges()
+    const internal = this.requiredInternal
 
     const candidates = new Map<ModuleJob, Plugin>()
     const invalidatedModules = new Set(this.accepted)
@@ -276,7 +292,7 @@ class Hmr extends Service {
         try {
           const { url } = await this._resolve(name, baseUrl, {})
           if (this.declined.has(url)) continue
-          const job = this.internal.loadCache.get(url)
+          const job = internal.loadCache.get(url)
           const plugin = this.ctx.loader.unwrapExports(job?.module?.getNamespace())
           if (!job || !plugin) continue
           candidates.set(job, plugin)
@@ -324,9 +340,9 @@ class Hmr extends Service {
     const require = createRequire(import.meta.url)
     for (const filename of invalidatedModules) {
       // Backup and clear ESM loadCache
-      const job = Map.prototype.get.call(this.internal.loadCache, filename)
+      const job = Map.prototype.get.call(internal.loadCache, filename)
       esmBackup[filename] = job
-      Map.prototype.delete.call(this.internal.loadCache, filename)
+      Map.prototype.delete.call(internal.loadCache, filename)
 
       // Backup and clear CJS Module._cache
       try {
@@ -342,7 +358,7 @@ class Hmr extends Service {
 
     const rollback = () => {
       for (const filename in esmBackup) {
-        Map.prototype.set.call(this.internal.loadCache, filename, esmBackup[filename])
+        Map.prototype.set.call(internal.loadCache, filename, esmBackup[filename])
       }
       for (const filepath in cjsBackup) {
         require.cache[filepath] = cjsBackup[filepath]

--- a/packages/hmr/tests/index.spec.ts
+++ b/packages/hmr/tests/index.spec.ts
@@ -1,6 +1,8 @@
 import { Context, Fiber } from 'cordis'
 import Loader from '@cordisjs/plugin-loader'
 import Logger from '@cordisjs/plugin-logger-console'
+import Timer from '@cordisjs/plugin-timer'
+import Hmr from '@cordisjs/plugin-hmr'
 import { writeFileSync, readFileSync, unlinkSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { expect, describe, it, beforeAll, afterAll, afterEach } from 'vitest'
@@ -75,7 +77,67 @@ async function createContext(configFile: string): Promise<{ ctx: Context; fiber:
 // Settle time after file restore, to let any triggered HMR finish
 const SETTLE_MS = 500
 
+// Standalone context (Logger + Timer + Loader) for the watch-only cases.
+async function createStandaloneContext(): Promise<{ ctx: Context; fiber: Fiber<Context> }> {
+  const ctx = new Context()
+  ctx.baseUrl = pathToFileURL(resolve(testDir) + '/').href
+  await ctx.plugin(Logger)
+  await ctx.plugin(Timer)
+  const fiber = await ctx.plugin(Loader)
+  return { ctx, fiber }
+}
+
 describe('HMR', () => {
+  // ===== Watch-only without loader internals =====
+  // Regression: watch-only mode (root: []) must boot without the native helper binding.
+  describe('watch-only without loader internals', () => {
+    it('should start in watch-only mode without loader internals', async () => {
+      const { ctx, fiber } = await createStandaloneContext()
+      // Simulate a missing native helper binding: fromInternal() returns
+      // undefined in production when the addon cannot resolve.
+      ctx.loader.internal = undefined
+
+      await ctx.plugin(Hmr, { root: [], debounce: 100, ignored: [] })
+
+      expect(ctx.hmr).to.be.ok
+      // watch-only mode must not wire up the reload path
+      expect((ctx.hmr as any).watcher).to.be.undefined
+
+      fiber?.dispose()
+      await new Promise(r => setTimeout(r, SETTLE_MS))
+    }, 10000)
+
+    it('should start in watch-only mode when loader internals are available', async (t) => {
+      const { ctx, fiber } = await createStandaloneContext()
+      // Skips when the runner lacks --expose-internals (the missing-binding cell is covered above).
+      if (!ctx.loader.internal) {
+        fiber?.dispose()
+        t.skip()
+        return
+      }
+      expect(ctx.loader.internal).to.be.ok
+      await ctx.plugin(Hmr, { root: [], debounce: 100, ignored: [] })
+
+      expect(ctx.hmr).to.be.ok
+      // watch-only mode must not wire up the reload path
+      expect((ctx.hmr as any).watcher).to.be.undefined
+
+      fiber?.dispose()
+      await new Promise(r => setTimeout(r, SETTLE_MS))
+    }, 10000)
+
+    it('should still require loader internals for module reload', async () => {
+      const { ctx, fiber } = await createStandaloneContext()
+      ctx.loader.internal = undefined
+
+      await expect(ctx.plugin(Hmr, { root: ['.'], debounce: 100, ignored: [] }))
+        .rejects.toThrow(/loader internals/)
+
+      fiber?.dispose()
+      await new Promise(r => setTimeout(r, SETTLE_MS))
+    }, 10000)
+  })
+
   // ===== Basic single plugin tests =====
   describe('basic single plugin', () => {
     let ctx: Context


### PR DESCRIPTION
## Summary

`Hmr` requires `loader.internal` unconditionally in its constructor, but `ModuleLoader.fromInternal()` returns `ModuleLoader | undefined`: the loader declares the field optional, while the HMR service consumed it as required. Watch-only mounts (`root: []`) crash when the native helper binding is unavailable.

## Changes

- Constructor only requires `loader.internal` when `root.length > 0`; the `loadCache` access in `[Service.init]()` is gated by the same check.
- `internal` is typed `ModuleLoader | undefined`; module-reload paths use a non-null accessor, `getLinked` degrades to `[]`.
- `_resolve` gains a default branch that throws on an unrecognized loader internal version (e.g. a future Node major), so consumers get a clear error rather than undefined.
- The watcher is only created when roots are configured; the error message states both ways out (`--expose-internals` or watch-only `root: []`).
- Tests: 3 new cases — watch-only boots with and without loader internals (asserting no watcher is created), and module-reload still requires internals. Module-reload with internals available is covered by the existing suite.
- Refactor: shared `isBuiltinOrExternal` helper (was duplicated in `loadDependencies` and `analyzeChanges`); `LOADER_INTERNALS_ERROR` constant.

## Verification

- The package test suite passes (39/39, vitest), including the new regression cases.





