### PR TITLE
fix(core): use a null-prototype hook map

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -43,7 +43,7 @@ export interface Hook extends EventOptions {
 }
 
 export class EventsService {
-  _hooks: Record<keyof any, Hook[]> = {}
+  _hooks: Record<keyof any, Hook[]> = Object.create(null)
 
   constructor(private ctx: Context) {
     defineProperty(this, symbols.tracker, {


### PR DESCRIPTION
### What changed
Initialize `EventsService._hooks` with `Object.create(null)`.

### Why
This avoids inherited-prototype keys such as `constructor` and `toString` being mistaken for registered hook arrays.

### Checks
- `corepack yarn test core`
- `corepack yarn lint packages/core/src/events.ts`