### PR TITLE
fix(core): preserve service caller from root

### DIFF
--- a/packages/core/src/reflect.ts
+++ b/packages/core/src/reflect.ts
@@ -76,7 +76,7 @@ export class ReflectService {
           return def.get.call(ctx, ctx[symbols.receiver], error)
         }
 
-        if (!ctx.fiber.runtime) return ctx.reflect.get(prop, false)
+        if (!ctx.fiber.runtime && !ctx[symbols.shadow]) return ctx.reflect.get(prop, false)
         return ctx.events.waterfall('internal/get', ctx, prop, error, () => {
           const key = target[symbols.isolate][prop]
           let fiber = (ctx[symbols.shadow] as Context ?? ctx).fiber

--- a/packages/core/tests/shadow.spec.ts
+++ b/packages/core/tests/shadow.spec.ts
@@ -41,6 +41,11 @@ describe('Traceable caller', () => {
     await root.plugin(Inner)
     await root.plugin(Outer)
 
+    const direct = root['outer'].inspect()
+    expect(direct.caller).toBe(outerOrigin!)
+    expect(direct.shadow).toBe(innerOrigin!)
+    expect(direct.outerShadow).toBe(outerOrigin!)
+
     let result!: ReturnType<Outer['inspect']>
     await root.inject(['outer'], (ctx) => {
       result = ctx['outer'].inspect()


### PR DESCRIPTION
当前实现下 ctx.root.a.b 丢失 shadow 从而忽略 b 对 a 的 inject 检查