### PR TITLE
fix(core): drain effects registered during unload

### DIFF
--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -13,6 +13,11 @@ declare module './context' {
 
 const kValidationError = Symbol.for('ValidationError')
 
+// Each extra unload round means a disposer registered new effects during
+// teardown, so legitimate nesting depth is tiny; the bound only stops
+// runaway registration loops from hanging `_unload`.
+const MAX_UNLOAD_ROUNDS = 16
+
 export class ValidationError extends TypeError {
   name = 'ValidationError'
 
@@ -435,17 +440,26 @@ export class Fiber {
   }
 
   private async _unload() {
-    await Promise.all(this._disposables.clear().map(async (dispose) => {
-      try {
-        await composeError(async (info) => {
-          await Promise.resolve()
-          info.error = new Error()
-          await dispose()
-        }, this._runner.getOuterStack)
-      } catch (reason) {
-        this.ctx.logger.error(reason)
-      }
-    }))
+    // Disposers may register more effects before they settle. Preserve the
+    // initial async boundary and drain those effects before unload completes.
+    let rounds = MAX_UNLOAD_ROUNDS
+    do {
+      await Promise.all(this._disposables.clear().map(async (dispose) => {
+        try {
+          await composeError(async (info) => {
+            await Promise.resolve()
+            info.error = new Error()
+            await dispose()
+          }, this._runner.getOuterStack)
+        } catch (reason) {
+          this.ctx.logger.error(reason)
+        }
+      }))
+    } while (this._disposables.length && --rounds)
+    if (this._disposables.length) {
+      this._disposables.clear()
+      this.ctx.logger.error(new Error(`fiber did not settle within ${MAX_UNLOAD_ROUNDS} unload rounds (runaway effect registration?)`))
+    }
     this.store = undefined
     this._updateState(() => {
       if (this._runner.epoch === INACTIVE) {

--- a/packages/core/tests/fiber.spec.ts
+++ b/packages/core/tests/fiber.spec.ts
@@ -1,4 +1,4 @@
-import { Context, FiberState, Service } from '../src'
+import { Context, Fiber, FiberState, Service } from '../src'
 import { expect, describe, it, vi } from 'vitest'
 import { mock } from 'node:test'
 import { event, sleep, withTimers } from './utils'
@@ -61,6 +61,65 @@ describe('Fiber', () => {
     ])
     expect(fiber.state).to.equal(FiberState.PENDING)
   }))
+
+  it('dispose late plugin registered during unload', async () => {
+    const root = new Context()
+    const dispose = root.provide('foo', 1)
+    const listener = mock.fn()
+    let resume!: () => void
+    const barrier = new Promise<void>(resolve => { resume = resolve })
+    let child!: Fiber
+
+    const fiber = root.inject(['foo'], (ctx) => {
+      ctx.effect(async () => {
+        await barrier
+        child = await ctx.plugin((ctx) => {
+          ctx.on(event, listener)
+        })
+      })
+    })
+    await fiber
+
+    const task = Promise.resolve(dispose())
+    expect(fiber.state).to.equal(FiberState.UNLOADING)
+    resume()
+    await task
+    await fiber
+
+    expect(fiber.state).to.equal(FiberState.PENDING)
+    expect(child.uid).to.equal(null)
+    expect(fiber._disposables.length).to.equal(0)
+
+    await fiber.dispose()
+    root.emit(event)
+    expect(listener.mock.calls).to.have.length(0)
+    expect(root.registry.size).to.equal(0)
+  })
+
+  it('bound runaway effect registration during unload', async () => {
+    const root = new Context()
+    const dispose = root.provide('foo', 1)
+    const error = mock.fn()
+    ;(root.logger as any).error = error
+
+    const fiber = root.inject(['foo'], (ctx) => {
+      const register = () => {
+        ctx.effect(() => () => {
+          register()
+        })
+      }
+      register()
+    })
+    await fiber
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+
+    await Promise.resolve(dispose())
+    await fiber
+
+    expect(fiber.state).to.equal(FiberState.PENDING)
+    expect(fiber._disposables.length).to.equal(0)
+    expect(error.mock.calls).to.have.length(1)
+  })
 
   it('plugin error', async () => {
     const root = new Context()


### PR DESCRIPTION
While a fiber is unloading, a late async effect can still call `ctx.plugin()` — and it succeeds. But `_unload` has already grabbed and cleared the disposable list, so the new child's disposer is never called. After the parent is fully disposed, the child is still `ACTIVE` in the registry and its listeners keep firing. Nothing will ever clean it up.

This is easy to hit with HMR or config reconciliation: a plugin awaits something, its dependency goes away mid-await, the plugin wakes up during unload and registers a child.

Why it happens:

- `assertActive` only checks `uid`, so it lets an `UNLOADING` fiber register new effects;
- `_unload` calls `this._disposables.clear()` once and awaits that snapshot — anything added during those awaits goes into the now-empty list, and nobody ever reads it again.

The fix: keep draining. Instead of one pass over the snapshot, `_unload` loops until `_disposables` is empty, so anything registered mid-unload gets torn down too. I chose to tear down late children rather than reject late `ctx.plugin()` calls, so legitimate async effects that resolve mid-reload keep working — they just get disposed like everything else.

The loop is capped at 16 rounds, so a disposer that keeps registering new effects forever can't hang unload: it gets a `ctx.logger.error` and the leftovers are dropped. There's a test for that case too.

The new regression test fails on current `main` (`child.uid` is `2` instead of `null`, the orphan's listener still fires after dispose) and passes with the fix. Full suite: 165/165.

**How I found this:** I've been mechanizing the Cordis paper in Idris 2, mostly with AI agents doing the proof work under adversarial review: https://github.com/Termina1/dgamma. The paper's proof of Lemma 68 assumes every child registration is tied to a live step of the parent's activation, but the operational rules don't actually enforce that. So I had the agents check whether the real implementation has the same hole — and this race is it. The repo's README has the details and executable countermodels.

Side note: the same audit confirmed that name reuse is a non-issue here by construction (callback identity + monotonic fiber uids that are never recycled). That matters for the paper rather than the code: O-Insert only requires a name to be *currently* unused, while the Theorem 73 sorting argument relies on names *never* being reused — the guarantee the implementation actually provides. The theorem should state it as a hypothesis.
