### PR TITLE
fix(core): refuse effect/listener/plugin registration while a fiber is UNLOADING

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -147,7 +147,7 @@ export class EventsService {
     }
 
     // handle special events
-    this.ctx.fiber.assertActive()
+    this.ctx.fiber.assertRegistrable()
     listener = this.ctx.reflect.bind(listener)
     const result = this.bail(this.ctx, 'internal/listener', name, listener, options)
     if (result) return result

--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -222,7 +222,18 @@ export class Fiber {
   }
 
   assertActive() {
-    if (this.uid !== null) return
+    if (this.uid !== null && this.state !== FiberState.UNLOADING) return
+    throw new CordisError('INACTIVE_EFFECT')
+  }
+
+  /** Refuse effect/listener/plugin REGISTRATION while this fiber is UNLOADING
+   * (roadmap 74(a)): an undo that calls ctx.effect() during deactivation would
+   * be accepted by the disposed-only assertActive() check, and the resulting
+   * disposer leaks permanently — the unload snapshot was already taken. Unlike
+   * assertActive(), this is NOT used by update()/restart(), which must keep
+   * working through an inertial reload's UNLOADING pass. */
+  assertRegistrable() {
+    if (this.uid !== null && this.state !== FiberState.UNLOADING) return
     throw new CordisError('INACTIVE_EFFECT')
   }
 
@@ -275,7 +286,7 @@ export class Fiber {
   effect(execute: () => SyncEffect, label?: string): Disposable<Promise<void>>
   effect(execute: () => Effect, label?: string): AsyncDisposable<Promise<void>>
   effect(execute: () => Effect, label = 'anonymous'): any {
-    this.assertActive()
+    this.assertRegistrable()
 
     const disposables: Disposable[] = []
     const dispose = () => {

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -194,7 +194,7 @@ export class RegistryService {
     // check if it's a valid plugin
     const callback = this.resolve(plugin)
     if (!callback) throw new Error('invalid plugin, expect function or object with an "apply" method, received ' + typeof plugin)
-    this.ctx.fiber.assertActive()
+    this.ctx.fiber.assertRegistrable()
 
     let runtime = this._internal.get(callback)
     if (!runtime) {

--- a/packages/core/tests/fiber.spec.ts
+++ b/packages/core/tests/fiber.spec.ts
@@ -180,4 +180,41 @@ describe('Fiber', () => {
     expect(Object.hasOwn(consumer, 'state')).to.equal(false)
     expect(Object.hasOwn(consumer, 'inertia')).to.equal(false)
   })
+  it('refuses effect registration while UNLOADING (G5 residue)', withTimers(async (root) => {
+    // roadmap 74(a): an undo that registers a new effect during deactivation
+    // must be refused (INACTIVE_EFFECT), not accepted-and-leaked. The
+    // deactivation path: provider.dispose() withdraws 'svc' -> Rogue
+    // deactivates (passes through UNLOADING) -> its generator effect's undo
+    // runs -> ctx.effect() inside must throw.
+    let leaked = false
+    let leakDisposed = false
+    const Provider = {
+      name: 'Provider',
+      apply(ctx: any) {
+        ctx.provide('svc', {})
+      },
+    }
+    const Rogue = {
+      name: 'Rogue',
+      inject: ['svc'],
+      apply(ctx: any) {
+        ctx.effect(function* () {
+          yield () => {
+            ctx.effect(() => {
+              leaked = true
+              return () => { leakDisposed = true }
+            })
+          }
+        })
+      },
+    }
+    const provider = await root.plugin(Provider)
+    const rogue = await root.plugin(Rogue)
+    await provider.dispose() // withdraw svc -> Rogue deactivates -> undo runs
+    expect(leaked).to.equal(false)
+    expect(rogue.state).to.equal(FiberState.PENDING)
+    expect(rogue.getEffects().length).to.equal(0)
+    await rogue.dispose()
+    expect(leakDisposed).to.equal(false)
+  }))
 })


### PR DESCRIPTION
## Summary

`Fiber.assertActive()` only checked `uid !== null` — "not disposed", not
"not unloading". During a *deactivation* (a requirement is withdrawn and the
fiber survives as `PENDING`), an undo that calls `ctx.effect(...)` was
accepted, and the resulting disposer leaked permanently:

1. the new effect executed and its disposer was pushed into
   `fiber._disposables` — *after* `_unload` already `clear()`ed the list;
2. the fiber ended `PENDING` while still holding an effect
   (`fiber.getEffects().length > 0` on an inactive fiber);
3. even a later `fiber.dispose()` never ran that disposer, because the epoch
   is already `INACTIVE` and no further unload is triggered — **permanent
   residue**.

## Fix

The `UNLOADING` lifecycle check is added to a new `assertRegistrable()` used
by the *registration* entry points — `effect()`, `on()`, `plugin()` — and
NOT to `assertActive()` itself, because `update()` and `restart()` must keep
working through an inertial reload's `UNLOADING` pass (a broad guard broke
the existing "update config while injected service reloads" test).

```ts
assertRegistrable() {
  if (this.uid !== null && this.state !== FiberState.UNLOADING) return
  throw new CordisError('INACTIVE_EFFECT')
}
```

## Repro / regression test

`packages/core/tests/fiber.spec.ts` — "refuses effect registration while
UNLOADING (G5 residue)": a provider dispose withdraws `svc`, the consumer's
generator-effect undo calls `ctx.effect()` during teardown. Before the fix
`leaked === true` and the fiber holds 1 leaked effect; after, `leaked ===
false`, `getEffects().length === 0`, state `PENDING`.

Full core suite: **71 passed**.

## Notes

- This is the revl-requested hardening (docs/backends-roadmap.md item 74(a)):
  revl's TS tier pins this exact behavior. Related PR #39 (reentrant fiber
  lifecycle) guards `effect()` directly; this change places the guard on the
  shared registration path so `on()`/`plugin()` inherit it. The two can be
  reconciled during #39's review.
- `FAILED` fibers still pass (as before): `update()` on a failed fiber is a
  legitimate recovery path.