### PR TITLE
fix(core): do not re-enter lifecycle from a failed outcome

### DIFF
--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -399,6 +399,8 @@ export class Fiber {
   private _setEpoch(epoch: string) {
     const oldEpoch = this._runner.epoch
     if (epoch === oldEpoch) return
+    // a failed fiber only recovers through update(), which clears _error
+    if (this._error) return
     this._runner.epoch = epoch
     if (this.inertia) return
     this._updateState(() => {

--- a/packages/core/tests/fiber.spec.ts
+++ b/packages/core/tests/fiber.spec.ts
@@ -84,6 +84,36 @@ describe('Fiber', () => {
     expect(callback.mock.calls).to.have.length(1)
   })
 
+  it('failed fiber does not re-enter on dependency refresh', async () => {
+    const root = new Context()
+    ;(root.logger as any).error = mock.fn()
+    const apply = mock.fn(() => { throw new Error('boom') })
+    const dispose = root.provide('foo', 1)
+    const fiber = root.inject(['foo'], apply)
+    await sleep()
+    expect(fiber.state).to.equal(FiberState.FAILED)
+    await dispose()
+    root.provide('foo', 2)
+    await sleep()
+    expect(apply.mock.calls).to.have.length(1)
+    expect(fiber.state).to.equal(FiberState.FAILED)
+  })
+
+  it('update recovers a failed fiber', async () => {
+    const root = new Context()
+    ;(root.logger as any).error = mock.fn()
+    const apply = mock.fn(() => { throw new Error('boom') })
+    root.provide('foo', 1)
+    const fiber = root.inject(['foo'], apply)
+    await sleep()
+    expect(fiber.state).to.equal(FiberState.FAILED)
+    apply.mock.mockImplementationOnce(() => {})
+    fiber.update()
+    await fiber
+    expect(apply.mock.calls).to.have.length(2)
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+  })
+
   it('dispose error', async () => {
     const root = new Context()
     const error = mock.fn()


### PR DESCRIPTION
fix #95

After a plugin fails, a dependency refresh can make the target satisfiable again and start `_reload()` while `_error` is still set, so the body runs again but the fiber keeps reporting FAILED. Skip epoch-driven lifecycle transitions while failed; `update()` clears `_error` and restarts.