### PR TITLE
fix(core): guard invalid plugin config schemas

### DIFF
--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -33,8 +33,12 @@ Object.defineProperty(ValidationError.prototype, kValidationError, {
 
 export function resolveConfig(runtime: Plugin.Runtime, config: any) {
   if (!runtime.Config) return config
+  const standard = runtime.Config['~standard']
+  if (!standard || typeof standard.validate !== 'function') {
+    throw new TypeError('plugin Config must implement Standard Schema V1')
+  }
   // TODO: async validation
-  const result = runtime.Config['~standard'].validate(config)
+  const result = standard.validate(config)
   if ('then' in result) {
     throw new TypeError('Async config validation is not supported')
   }

--- a/packages/core/tests/fiber.spec.ts
+++ b/packages/core/tests/fiber.spec.ts
@@ -84,6 +84,22 @@ describe('Fiber', () => {
     expect(callback.mock.calls).to.have.length(1)
   })
 
+  it('rejects invalid plugin config schema before apply', async () => {
+    const root = new Context()
+    const apply = mock.fn()
+    ;(root.logger as any).error = mock.fn()
+
+    const plugin = {
+      Config: {} as any,
+      apply,
+    }
+
+    await expect(root.plugin(plugin)).rejects.toThrow(
+      'plugin Config must implement Standard Schema V1',
+    )
+    expect(apply.mock.calls).to.have.length(0)
+  })
+
   it('failed fiber does not re-enter on dependency refresh', async () => {
     const root = new Context()
     ;(root.logger as any).error = mock.fn()


### PR DESCRIPTION
Fixes #102.

`resolveConfig()` currently assumes every truthy plugin `Config` exposes `~standard.validate`, so an invalid runtime config fails with an opaque `undefined.validate` TypeError.

This adds a runtime guard before validation and reports the actual Standard Schema contract violation. The regression test also verifies that an invalid `Config` is rejected before the plugin's `apply()` runs.

## Tests

* `yarn test core`
* `yarn lint`
* `yarn build core`
* `yarn build`
* `yarn test`
