### PR TITLE
fix(loader): detect internal API by runtime shape

### DIFF
--- a/packages/loader/src/internal.ts
+++ b/packages/loader/src/internal.ts
@@ -111,13 +111,14 @@ export namespace ModuleLoader {
   export function fromInternal(): ModuleLoader | undefined {
     if (_cachedLoader) return _cachedLoader
     const [major] = process.versions.node.split('.').map(Number)
+    if (major < 22) return
 
-    if (major >= 24) {
-      const raw = requireInternal('internal/modules/esm/loader')?.getOrInitializeCascadedLoader()
-      if (raw) return _cachedLoader = Object.assign(raw, { version: 'v2' })
-    } else if (major >= 22) {
-      const raw = requireInternal('internal/modules/esm/loader')?.getOrInitializeCascadedLoader()
-      if (raw) return _cachedLoader = Object.assign(raw, { version: 'v1' })
-    }
+    const raw = requireInternal('internal/modules/esm/loader')?.getOrInitializeCascadedLoader()
+    if (!raw) return
+    const version = typeof raw.getOrCreateModuleJob === 'function'
+      ? 'v2'
+      : typeof raw.getModuleJobForImport === 'function' ? 'v1' : undefined
+    if (!version) return
+    return _cachedLoader = Object.assign(raw, { version })
   }
 }

--- a/packages/loader/tests/internal.spec.ts
+++ b/packages/loader/tests/internal.spec.ts
@@ -1,0 +1,27 @@
+import { execFileSync } from 'node:child_process'
+import { expect, describe, it } from 'vitest'
+
+describe('ModuleLoader.fromInternal', () => {
+  it('classifies the Node 24.9 loader by its runtime shape', () => {
+    const source = new URL('../src/internal.ts', import.meta.url).href
+    const script = `
+      import { createRequire } from 'node:module'
+      const { ModuleLoader } = await import(${JSON.stringify(source)})
+      const require = createRequire(import.meta.url)
+      const internal = require('internal/modules/esm/loader')
+      internal.getOrInitializeCascadedLoader = () => ({ getModuleJobForImport() {} })
+      Object.defineProperty(process.versions, 'node', { value: '24.9.0' })
+      console.log(ModuleLoader.fromInternal()?.version)
+    `
+    const output = execFileSync(process.execPath, [
+      '--no-deprecation',
+      '--expose-internals',
+      '--import',
+      'tsx',
+      '--input-type=module',
+      '--eval',
+      script,
+    ], { encoding: 'utf8' })
+    expect(output.trim()).to.equal('v1')
+  })
+})


### PR DESCRIPTION
Closes #105.

## Problem

`ModuleLoader.fromInternal()` currently treats every Node major version at least 24 as the v2 internal ESM loader API. Node 24.9 still exposes the v1 API (`getModuleJobForImport`), so consumers call `resolveSync()` with the reversed v2 parameter order and receive a `TypeError`.

The observed transition is between Node 24.9 (v1) and Node 24.12 (v2). `resolveSync.length` is `2` in both versions, so arity is not a safe discriminator.

## Change

- classify the runtime loader by `getOrCreateModuleJob` (v2) or `getModuleJobForImport` (v1)
- return `undefined` for an unknown shape instead of guessing
- add a subprocess regression that presents a v1-shaped loader while reporting Node 24.9

The shape-detection fix is ported from DeepSeek Harness's vendored Cordis copy (deepseek-ai/deepseek-harness@675efe73); the original downstream author is retained as a co-author. The focused regression is new in this PR.

## Verification

- `yarn test loader` — 4 files, 38 tests passed
- mutation check — restoring the major-version classifier makes the new test fail with `expected 'v2' to equal 'v1'`
- `yarn build core && yarn build`
- `yarn lint`
- `git diff --check`
- real runtime probe: Node 24.9.0 → v1; Node 24.12.0 → v2; Node 26.7.0 → v2
