### PR TITLE
fix(packages): remove unpublished source exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,6 @@
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     },
-    "./src/*": "./src/*",
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/core/tests/package.spec.ts
+++ b/packages/core/tests/package.spec.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { describe, expect, it } from 'vitest'
+
+const execFileAsync = promisify(execFile)
+const yarn = {
+  command: process.platform === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : 'corepack',
+  prefix: process.platform === 'win32' ? ['/d', '/s', '/c', 'corepack.cmd', 'yarn'] : ['yarn'],
+}
+
+const packages = [
+  ['cordis', new URL('../package.json', import.meta.url)],
+  ['@cordisjs/plugin-loader', new URL('../../loader/package.json', import.meta.url)],
+  ['@cordisjs/plugin-timer', new URL('../../timer/package.json', import.meta.url)],
+] as const
+
+describe('Package', () => {
+  it.each(packages)('%s exposes only archive-backed entry points', async (name, manifestPath) => {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+    const { stdout } = await execFileAsync(yarn.command, [
+      ...yarn.prefix,
+      'workspace',
+      name,
+      'pack',
+      '--dry-run',
+      '--json',
+    ])
+    const entries = stdout.trim().split(/\r?\n/).map(line => JSON.parse(line))
+    const files = entries.map(entry => entry.location).filter(Boolean)
+
+    expect(manifest.exports).not.toHaveProperty('./src/*')
+    expect(manifest.publishConfig?.exports).toBeUndefined()
+    expect(files.some(file => file === 'src' || file.startsWith('src/'))).toBe(false)
+  })
+})

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -10,7 +10,6 @@
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     },
-    "./src/*": "./src/*",
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -10,7 +10,6 @@
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     },
-    "./src/*": "./src/*",
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
## Summary

The `cordis`, `@cordisjs/plugin-loader`, and `@cordisjs/plugin-timer`
packages export `./src/*`, while their published archives do not contain
`src`.

The source files were removed from the package file lists during the
pure-ESM migration, while the source subpath exports remained. Remove those
dangling exports so the published manifests only expose paths present in the
package archives. The package-root entry points and `./package.json` export
remain unchanged.

Related discussion: #46

## Verification

- `corepack yarn lint`
- `corepack yarn build core`
- `corepack yarn build`
- `corepack yarn test:json` (20 test files, 184 tests)
- `git diff --check`
- inspected the current npm Registry tarballs for all three packages
- packed the revised packages with npm and Yarn
- installed both sets of tarballs and verified package-root imports and TypeScript resolution
- verified the removed source subpaths fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`
- mutation check: restoring `./src/*` or adding `publishConfig.exports` fails the packaging regression tests
