### PR TITLE
fix(core): do not leave fiber failures unhandled

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,4 +1,4 @@
-import { defineProperty, Promisify } from 'cosmokit'
+import { Awaitable, defineProperty, Promisify } from 'cosmokit'
 import { Context } from './context'
 import { Fiber, FiberState } from './fiber'
 import { DisposableList, symbols } from './utils'
@@ -180,7 +180,7 @@ export interface Events {
   'internal/plugin'(fiber: Fiber): void
   'internal/status'(fiber: Fiber, oldValue: FiberState): void
   'internal/service'(this: Context, name: string, value: any): void
-  'internal/update'(this: Fiber, config: any, noSave: boolean, next: () => void): void
+  'internal/update'(this: Fiber, config: any, noSave: boolean, next: () => Awaitable<void>): Awaitable<void>
   'internal/get'(ctx: Context, name: string, error: Error, next: () => any): any
   'internal/set'(ctx: Context, name: string, value: any, error: Error, next: () => boolean): boolean
   'internal/listener'(this: Context, name: string, listener: any, prepend: boolean): void

--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -479,10 +479,18 @@ export class Fiber {
     const fiber = this.ctx.fiber
     fiber.assertActive()
     config = resolveConfig(fiber.runtime!, config)
-    return fiber.context.waterfall(fiber, 'internal/update', config, noSave, () => {
+    const result = fiber.context.waterfall(fiber, 'internal/update', config, noSave, () => {
       fiber.config = config
       fiber._error = undefined
       return fiber.restart()
     })
+    // a listener may veto the restart, in which case there is nothing to await
+    if (result === undefined) return
+    const task = Promise.resolve(result)
+    // the failure is already reported by the fiber, so mark it handled here:
+    // a caller that drops the result cannot turn it into an unhandled
+    // rejection, while `await update()` still observes it
+    task.catch(() => {})
+    return task
   }
 }

--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -475,11 +475,11 @@ export class Fiber {
     await fiber.await()
   }
 
-  update(config: any, noSave = false) {
+  update(config: any, noSave = false): Awaitable<void> {
     const fiber = this.ctx.fiber
     fiber.assertActive()
     config = resolveConfig(fiber.runtime!, config)
-    fiber.context.waterfall(fiber, 'internal/update', config, noSave, () => {
+    return fiber.context.waterfall(fiber, 'internal/update', config, noSave, () => {
       fiber.config = config
       fiber._error = undefined
       return fiber.restart()

--- a/packages/core/tests/fiber.spec.ts
+++ b/packages/core/tests/fiber.spec.ts
@@ -127,6 +127,22 @@ describe('Fiber', () => {
     expect(fiber.state).to.equal(FiberState.FAILED)
   })
 
+  // the fiber reports the failure itself, so a caller that never asks for the
+  // result must not be punished with an unhandled rejection
+  it('update does not leak a dropped failure', async () => {
+    const root = new Context()
+    ;(root.logger as any).error = mock.fn()
+    const apply = mock.fn(() => {})
+    const fiber = root.plugin(apply)
+    await fiber
+    apply.mock.mockImplementationOnce(() => {
+      throw new Error('boom')
+    })
+    fiber.update({})
+    await sleep()
+    expect(fiber.state).to.equal(FiberState.FAILED)
+  })
+
   it('dispose error', async () => {
     const root = new Context()
     const error = mock.fn()

--- a/packages/core/tests/fiber.spec.ts
+++ b/packages/core/tests/fiber.spec.ts
@@ -114,6 +114,19 @@ describe('Fiber', () => {
     expect(fiber.state).to.equal(FiberState.ACTIVE)
   })
 
+  it('update surfaces a failed reload to its caller', async () => {
+    const root = new Context()
+    ;(root.logger as any).error = mock.fn()
+    const apply = mock.fn(() => {})
+    const fiber = root.plugin(apply)
+    await fiber
+    apply.mock.mockImplementationOnce(() => {
+      throw new Error('boom')
+    })
+    await expect(fiber.update({})).rejects.toThrow('boom')
+    expect(fiber.state).to.equal(FiberState.FAILED)
+  })
+
   it('dispose error', async () => {
     const root = new Context()
     const error = mock.fn()

--- a/packages/loader/src/config/entry.ts
+++ b/packages/loader/src/config/entry.ts
@@ -86,7 +86,9 @@ export class Entry {
       Object.setPrototypeOf(this.ctx, this.parent.ctx)
 
       if (this.fiber?.uid && (diff.includes('config') || this.options.group)) {
-        this.fiber.update(this._resolveConfig(this.fiber.runtime!.callback), true)
+        const config = this._resolveConfig(this.fiber.runtime!.callback)
+        // failures are already reported by the fiber; do not let them float
+        Promise.resolve(this.fiber.update(config, true)).catch(() => {})
       }
     })
   }
@@ -149,7 +151,8 @@ export class Entry {
     } finally {
       this._initTask = undefined
     }
-    this.fiber?.await().finally(() => {
+    // failures are already reported by the fiber; we only need it to settle
+    this.fiber?.await().catch(() => {}).finally(() => {
       if (this.loader.getTasks().length) return
       this.ctx.reflect.notify(['loader'])
     })

--- a/packages/loader/src/config/entry.ts
+++ b/packages/loader/src/config/entry.ts
@@ -86,9 +86,7 @@ export class Entry {
       Object.setPrototypeOf(this.ctx, this.parent.ctx)
 
       if (this.fiber?.uid && (diff.includes('config') || this.options.group)) {
-        const config = this._resolveConfig(this.fiber.runtime!.callback)
-        // failures are already reported by the fiber; do not let them float
-        Promise.resolve(this.fiber.update(config, true)).catch(() => {})
+        this.fiber.update(this._resolveConfig(this.fiber.runtime!.callback), true)
       }
     })
   }

--- a/packages/loader/tests/index.spec.ts
+++ b/packages/loader/tests/index.spec.ts
@@ -110,7 +110,7 @@ describe('Loader: intercept config', () => {
     loader = root.loader as any
 
     loader.mock('foo', () => promise)
-    Object.assign(loader.mock('bar', (ctx: Context) => ctx.on('internal/update', () => true)), {
+    Object.assign(loader.mock('bar', (ctx: Context) => ctx.on('internal/update', () => {})), {
       inject: ['never'],
     })
     loader.mock('qux', () => {})

--- a/packages/loader/tests/index.spec.ts
+++ b/packages/loader/tests/index.spec.ts
@@ -149,3 +149,48 @@ describe('Loader: intercept config', () => {
     expect(loader.expectFiber(qux).state).to.equal(FiberState.ACTIVE)
   })
 })
+
+// a failing entry is reported by the fiber itself; it must not escape as an
+// unhandled rejection, which would take the whole process down with it
+describe('Loader: entry failure', () => {
+  const root = new Context()
+
+  let loader!: MockLoader
+
+  beforeAll(async () => {
+    await root.plugin(MockLoader)
+    loader = root.loader as any
+
+    loader.mock('bad', () => {
+      throw new Error('boom')
+    })
+    loader.mock('good', () => {})
+  })
+
+  it('on load', async () => {
+    await loader.read([{
+      id: '1',
+      name: 'bad',
+    }, {
+      id: '2',
+      name: 'good',
+    }])
+
+    expect(loader.expectFiber('1').state).to.equal(FiberState.FAILED)
+    expect(loader.expectFiber('2').state).to.equal(FiberState.ACTIVE)
+  })
+
+  it('on config update', async () => {
+    await loader.read([{
+      id: '1',
+      name: 'bad',
+      config: { a: 1 },
+    }, {
+      id: '2',
+      name: 'good',
+    }])
+
+    expect(loader.expectFiber('1').state).to.equal(FiberState.FAILED)
+    expect(loader.expectFiber('2').state).to.equal(FiberState.ACTIVE)
+  })
+})


### PR DESCRIPTION
fix #108

`_reload()` already treats a plugin failure as terminal: it logs the error and leaves the fiber FAILED. `await()` rethrows it for callers that ask, but two loader paths never ask — `Entry.init()` only sequences on the fiber settling, and `_patchContext()` fires `update()` and walks away. The same error is delivered a second time with nobody listening, and the process dies on the unhandled rejection without running a single disposer. `update()` compounds this by discarding the continuation, leaving no way to observe it from outside.

Return the lifecycle promise from `update()`; swallow it at the two sites that deliberately do not wait.
