### PR TITLE
fix(core): tear down providers after their consumers

### DIFF
--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -109,6 +109,7 @@ export class Fiber {
   public store: Dict<Impl> | undefined
   public inertia: Promise<void> | undefined
 
+  public _releasing = false
   public readonly _hooks: Dict<DisposableList<Function>> = Object.create(null)
   public readonly _disposables = new DisposableList<Disposable>()
 
@@ -167,7 +168,7 @@ export class Fiber {
         this._checkImpl(name)
       }
 
-      this.dispose = parent.fiber.effect(() => {
+      this.dispose = defineProperty(parent.fiber.effect(() => {
         const remove = runtime.fibers.push(this)
         try {
           this.config = resolveConfig(runtime, config)
@@ -195,8 +196,11 @@ export class Fiber {
           while (this.inertia) {
             await this.inertia
           }
+          for (const name of Object.keys(this._store)) {
+            this._setImpl(name)
+          }
         }
-      }, 'ctx.plugin()')
+      }, 'ctx.plugin()'), symbols.plugin, true)
     } else {
       this.uid = 0
       this.ctx = this.context = parent
@@ -368,18 +372,30 @@ export class Fiber {
     }
   }
 
+  private _setImpl(name: string, impl?: Impl) {
+    const oldImpl = this._store[name]
+    if (oldImpl === impl) return
+    oldImpl?.consumers.delete(this)
+    if (impl) {
+      this._store[name] = impl
+      impl.consumers.add(this)
+    } else {
+      delete this._store[name]
+    }
+  }
+
   _checkImpl(name: string) {
     const impl = this.ctx.reflect._getImpl(name, true)
-    if (!impl) return delete this._store[name]
+    if (!impl) return this._setImpl(name)
     try {
       if (impl.check && !impl.check.call(getTraceable(this.ctx, impl.value))) {
-        return delete this._store[name]
+        return this._setImpl(name)
       }
     } catch (error) {
       impl.fiber.ctx.logger.error(error)
-      return delete this._store[name]
+      return this._setImpl(name)
     }
-    this._store[name] = impl
+    this._setImpl(name, impl)
   }
 
   _refresh() {
@@ -437,7 +453,7 @@ export class Fiber {
   }
 
   private async _unload() {
-    await Promise.all(this._disposables.clear().map(async (dispose) => {
+    const run = async (dispose: Disposable) => {
       try {
         await composeError(async (info) => {
           await Promise.resolve()
@@ -447,7 +463,20 @@ export class Fiber {
       } catch (reason) {
         this.ctx.logger.error(reason)
       }
-    }))
+    }
+    // a provider must relinquish its services, and let consumers finish, before
+    // tearing down the resources those consumers are still using
+    // 1. child fibers, which may consume services this fiber provides
+    // 2. our own services, waiting for any consumer left outside this subtree
+    // 3. everything else, i.e. the resources those consumers were still using
+    const disposables = this._disposables.clear()
+    await Promise.all(disposables.filter(dispose => dispose[symbols.plugin]).map(run))
+    this._releasing = true
+    await Promise.all(disposables.filter(dispose => dispose[symbols.provide]).map(run))
+    this._releasing = false
+    await Promise.all(disposables
+      .filter(dispose => !dispose[symbols.plugin] && !dispose[symbols.provide])
+      .map(run))
     this.store = undefined
     this._updateState(() => {
       if (this._runner.epoch === INACTIVE) {

--- a/packages/core/src/reflect.ts
+++ b/packages/core/src/reflect.ts
@@ -56,6 +56,8 @@ export interface Impl {
   fiber: Fiber
   value?: any
   check?: () => boolean
+  /** fibers currently injecting this implementation */
+  consumers: Set<Fiber>
 }
 
 export class ReflectService {
@@ -175,7 +177,7 @@ export class ReflectService {
   }
 
   provide(name: string, value?: any, check?: () => boolean) {
-    return this.ctx.fiber.effect(() => {
+    return defineProperty(this.ctx.fiber.effect(() => {
       if (!this.props[name]) {
         this.props[name] ??= { type: 'service' }
       } else if (this.props[name].type !== 'service') {
@@ -185,7 +187,7 @@ export class ReflectService {
 
       this.ctx.root[symbols.isolate][name] ??= Symbol(name)
       const key = this.ctx[symbols.isolate][name]
-      const impl: Impl = { name, value, fiber: this.ctx.fiber, check }
+      const impl: Impl = { name, value, fiber: this.ctx.fiber, check, consumers: new Set() }
       if (this.store[key]) {
         throw new Error(`service "${name}" has been registered at <${this.store[key].fiber.name}>`)
       }
@@ -196,12 +198,18 @@ export class ReflectService {
       }
       return async () => {
         delete this.store[key]
-        const fibers = this.notify([name])
-        await Promise.allSettled(fibers.map(fiber => fiber.await()))
+        // `notify()` only sees fibers still attached to the registry, so a consumer
+        // that is already unloading is invisible to it — track them on the impl
+        const consumers = new Set(impl.consumers)
+        for (const fiber of this.notify([name])) consumers.add(fiber)
+        consumers.delete(impl.fiber)
+        // a consumer that is itself releasing services would deadlock on us
+        const pending = [...consumers].filter(fiber => !fiber._releasing)
+        await Promise.allSettled(pending.map(fiber => fiber.await()))
         // ensure self access before dependencies cleanup
         delete this.ctx.fiber.store![name]
       }
-    }, `ctx.provide(${JSON.stringify(name)})`)
+    }, `ctx.provide(${JSON.stringify(name)})`), symbols.provide, true)
   }
 
   notify(names: string[], filter = (ctx: Context, name: string) => ctx[symbols.isolate][name] === this.ctx[symbols.isolate][name]) {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -53,6 +53,8 @@ export const symbols = {
   metadata: Symbol.for('cordis.metadata'),
   initHooks: Symbol.for('cordis.initHooks'),
   checkProto: Symbol.for('cordis.checkProto'),
+  provide: Symbol.for('cordis.provide'),
+  plugin: Symbol.for('cordis.plugin'),
 
   // context symbols
   effect: Symbol.for('cordis.effect') as typeof Context.effect,

--- a/packages/core/tests/dispose.spec.ts
+++ b/packages/core/tests/dispose.spec.ts
@@ -1,4 +1,4 @@
-import { Context } from '../src'
+import { Context, Service } from '../src'
 import { expect, describe, it, vi } from 'vitest'
 import { mock } from 'node:test'
 import { sleep, withTimers } from './utils'
@@ -217,6 +217,35 @@ describe('Effects', () => {
     expect(seq).to.deep.equal([])
     await expect(dispose).rejects.toThrow()
     expect(seq).to.deep.equal([])
+  })
+
+  it('provider is torn down after its consumers', async () => {
+    const root = new Context()
+    const order: string[] = []
+
+    class Provider extends Service {
+      constructor(ctx: Context) {
+        super(ctx, 'foo')
+      }
+
+      * [Service.init]() {
+        yield () => order.push('provider')
+      }
+    }
+
+    const fiber = await root.plugin((ctx) => {
+      ctx.plugin(Provider)
+      ctx.inject(['foo'], (ctx) => {
+        ctx.effect(() => async () => {
+          await sleep(10)
+          order.push('consumer')
+        })
+      })
+    })
+    await sleep()
+
+    await fiber.dispose()
+    expect(order).to.deep.equal(['consumer', 'provider'])
   })
 
   it('async yield with error', async () => {

--- a/packages/loader/src/config/group.ts
+++ b/packages/loader/src/config/group.ts
@@ -36,6 +36,9 @@ export class EntryGroup {
   remove(id: string, isDispose = false) {
     const entry = this.tree.store[id]
     if (!entry) return
+    // the entry may have been moved to another group, in which case it is no
+    // longer ours to dispose
+    if (entry.parent !== this) return
     entry.fiber?.dispose()
     if (!isDispose) {
       this.unlink(entry.options)


### PR DESCRIPTION
fix #26
(A old issue, and quite hard to fix to be honest...take muuuch longer time than i expected :))

## Problem

`Fiber._unload()` disposed all of a fiber's effects concurrently through a single `Promise.all`. Nothing ordered a service's teardown against the teardown of the fibers still using it, so a provider could release its resources while a consumer was midway through its own asynchronous disposal.

The repro in #26 is a `Logger` service holding a `WriteStream`. Its consumer does some work before writing a final line:

```ts
ctx.plugin(Logger, { target: 'log.txt' })

ctx.inject(['logger'], (c) => {
  c.effect(() => {
    c.logger.log('start')
    return async () => {
      await sleep(3000)   // some extra work before dispose
      c.logger.log('end')
    }
  })
})
```

On disposal the stream is closed first and the final write fails with `write after end`. `log.txt` keeps `start` and loses `end`.

This is not a missing guarantee so much as a broken one. `ReflectService.provide()` already waits for dependent fibers, and its comment states the intent — *ensure self access before dependencies cleanup*. The wait never has any effect, for two independent reasons:

1. It discovers consumers through `notify()`, which walks `registry.values()` → `runtime.fibers`. A consumer that is already unloading has been detached from its runtime and is therefore invisible. Instrumenting the disposer in the repro above shows it finding **zero** consumers.
2. Even with the right set, the disposer runs concurrently with its own fiber's other disposers, so the resource is gone regardless of what it waits for.

## Change

Unloading now runs in three phases, still fully concurrent within each phase:

| Phase | Disposers | Rationale |
| --- | --- | --- |
| 1 | child fibers (`ctx.plugin()`) | they may consume services this fiber provides |
| 2 | own services (`ctx.provide()`) |  outside this subtree |
| 3 | everything else | the resources those consumers were still using |

Phases 1 and 2 are separate because a consumer inside this fiber's own subtree is disposed by phase 1;
waiting for it from phase 2 would otheris fiber has not started yet.

Consumers are now recorded on the impl er._checkImpl`) instead of beingrediscovered from the registry at teardown, which closes the visibility gap in (1). A consumer that is
itself in its service-release phase is viding services to each other cannotdeadlock.

## Collateral fix

The reordering makes an existing bug in `EntryGroup.remove()` reproducible rather than incidental. It
resolves an id against the shared `treever it finds, without checking that theentry still belongs to this group, so a group's teardown could dispose an entry that has since been
reparented. Deferring `Group.stop()` to race into a consistent failure, visibleas `plugin self-update` and `plugin self-dispose` writing a spurious `disabled: true`. `remove()` now
verifies ownership first.

This change is required by the reorderi cleanup.

## Validation

- `yarn test` 182 passed, 33.2s (nealy same with baseline.
- `yarn lint`, clean `yarn build` with no errors
- the new `provider is torn down after without this change
- the #26 repro now writes both `start` and `end`