### PR TITLE
fix(loader): remove nested entries by local id

### DIFF
--- a/packages/loader/src/config/tree.ts
+++ b/packages/loader/src/config/tree.ts
@@ -82,7 +82,7 @@ export abstract class EntryTree {
 
   remove(id: string) {
     const entry = this.resolve(id)
-    entry.parent.remove(id)
+    entry.parent.remove(entry.options.id)
     entry.parent.tree.write()
   }
 

--- a/packages/loader/tests/group.spec.ts
+++ b/packages/loader/tests/group.spec.ts
@@ -1,7 +1,45 @@
 import { Mock, mock } from 'node:test'
 import { expect, describe, it, beforeAll, beforeEach } from 'vitest'
 import { Context } from 'cordis'
+import { EntryTree } from '../src'
 import MockLoader, { sleep } from './utils'
+
+describe('Tree: nested removal', () => {
+  it('removes an entry addressed by its composite id', async () => {
+    const root = new Context()
+    await root.plugin(MockLoader)
+    const loader = root.loader as MockLoader
+    const dispose = mock.fn()
+    loader.mock('foo', () => dispose)
+
+    class NestedTree extends EntryTree {
+      write() {}
+
+      import(name: string) {
+        return loader.import(name)
+      }
+    }
+
+    let tree!: NestedTree
+    loader.mock('tree', async (ctx) => {
+      tree = new NestedTree(ctx)
+      await tree.root.update([{ id: 'child', name: 'foo' }])
+      return () => tree.root.stop()
+    })
+
+    const outer = await loader.create({ name: 'tree' })
+    await loader.await()
+    const child = `${outer}${EntryTree.sep}child`
+    expect(loader.resolve(child).fiber).to.be.ok
+
+    loader.remove(child)
+    await sleep()
+
+    expect(() => loader.resolve(child)).to.throw(`cannot resolve entry ${child}`)
+    expect(dispose.mock.calls).to.have.length(1)
+    expect(tree.root.data).to.deep.equal([])
+  })
+})
 
 describe('Group: basic support', () => {
   const root = new Context()


### PR DESCRIPTION
Closes #114.

## Problem

`EntryTree.remove()` accepts the same composite ids resolved by `EntryTree.resolve()`. After resolving a nested id such as `parent:child`, it passes that full path to `EntryGroup.remove()`. The group already belongs to the child tree and its store is keyed by the local id (`child`), so the lookup misses.

The call returns without an error while the nested entry remains resolvable, its fiber remains live, its disposer is not called, and the tree data is unchanged.

This reproduces on current main and the published `@cordisjs/plugin-loader@1.0.0-rc.6`.

## Change

Remove the resolved entry using `entry.options.id`, its id in the owning tree.

Top-level entries are unchanged because their public and local ids are the same. Nested entries now reach the existing `EntryGroup.remove()` lifecycle, which disposes the fiber, unlinks the options, deletes the store entry, and emits `loader/partial-dispose`.

## Regression coverage

The new test mounts a real nested `EntryTree`, starts a child plugin, removes it through its composite id, and verifies all three externally meaningful outcomes:

- the composite id no longer resolves;
- the child disposer runs exactly once;
- the child is removed from the nested tree data.

Restoring the old full-id call makes the regression fail because the child still resolves.

## Validation

- Node 24.19.0: `yarn test loader` — 4 files, 41 tests passed
- Node 26.7.0: `yarn test loader` — 4 files, 41 tests passed
- Node 24.19.0: `yarn test:json` — 20 files, 187 tests passed
- Node 26.7.0: `yarn test:json` — 20 files, 187 tests passed
- `yarn build core && yarn build`
- `yarn lint`
- `git diff --check`
