### PR TITLE
fix(include): apply patches to rows inserted by earlier patches

### DIFF
--- a/packages/include/src/index.ts
+++ b/packages/include/src/index.ts
@@ -132,6 +132,8 @@ export class Include extends EntryTree {
         } else {
           data.push(...insert)
         }
+        // Index inserted rows so later patches in the same list can address them.
+        buildMap(insert)
         continue
       }
 

--- a/packages/include/tests/patch.spec.ts
+++ b/packages/include/tests/patch.spec.ts
@@ -221,6 +221,33 @@ describe('Include patches', () => {
     expect(ctx.bail('test/get-extra')).to.equal('extra')
   }, 10000)
 
+  it('should let a later patch address a row inserted by an earlier patch', async () => {
+    ctx = new Context()
+    await ctx.plugin(LoggerConsole)
+    fiber = await ctx.plugin(Loader, {
+      baseUrl: import.meta.url,
+    })
+    await ctx.loader.create({
+      name: '@cordisjs/plugin-include',
+      config: {
+        path: './fixtures/base.yml',
+        patches: [
+          {
+            insert: [
+              { id: 'added', name: './extra-plugin' },
+            ],
+          },
+          { id: 'added', disabled: true },
+        ],
+      },
+    })
+    await new Promise(r => setTimeout(r, 1000))
+    // The row inserted by the first patch is disabled by the second patch,
+    // so the extra plugin must NOT be loaded.
+    expect(ctx.bail('test/get-extra')).to.be.undefined
+    expect(ctx.bail('test/get-value')).to.equal('default')
+  }, 10000)
+
   it('should validate name consistency (matching name is ok)', async () => {
     ctx = new Context()
     await ctx.plugin(LoggerConsole)


### PR DESCRIPTION
Fixes #112.

applyEntryPatches builds the index map once, before applying any patches, so a patch that inserts a row and a later patch that addresses that inserted row silently miss each other. deepseek-harness vendors this loader and hits the bug when profile overlays insert a row and then patch that same row.

Fix: rebuild the map after each insert so later patches can see rows inserted by earlier ones. Adds a regression test that fails on main (the later patch's update lands on nothing) and passes with the fix; the include test file runs 11/11.

Reproduction details and a note about the related Windows write race are in #112.