### PR TITLE
fix(loader): surface diagnostics from requireInternal fallback

### DIFF
--- a/packages/loader/src/internal.ts
+++ b/packages/loader/src/internal.ts
@@ -101,11 +101,17 @@ export namespace ModuleLoader {
     if (process.execArgv.includes('--expose-internals')) {
       try {
         return require(id)
-      } catch {}
+      } catch (e) {
+        console.debug('cordis:loader: --expose-internals path failed for %s: %o', id, e)
+      }
     }
     try {
       return require('node-addon-require-builtin').requireBuiltin(id)
-    } catch {}
+    } catch (e) {
+      // Keep returning undefined (HMR relies on graceful degradation); log why.
+      console.debug('cordis:loader: node-addon-require-builtin path failed for %s: %o', id, e)
+      console.debug('cordis:loader: this is often caused by pnpm 10+ isolated layout, missing platform binding, or Node version drift; see https://github.com/cordiverse/cordis/issues?q=is%3Aissue+loader.internal')
+    }
   }
 
   /**

--- a/packages/loader/tests/internal.spec.ts
+++ b/packages/loader/tests/internal.spec.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ModuleLoader } from '../src'
 
 describe('ModuleLoader.fromInternal', () => {
@@ -12,5 +12,51 @@ describe('ModuleLoader.fromInternal', () => {
       ? loader!.resolveSync(import.meta.url, { specifier: 'node:path', attributes: {} })
       : loader!.resolveSync('node:path', import.meta.url, {})
     expect(resolved.url).to.equal('node:path')
+  })
+})
+
+// Regression coverage for the silent `catch {}` in requireInternal(): the
+// fallback used to swallow errors, leaving callers with a misleading
+// "--expose-internals is required" string. Now it logs a `cordis:loader:`
+// debug line and still returns undefined, so HMR can degrade gracefully.
+//
+// vi.doMock keeps the mock scoped to the dynamic import below; the
+// real-require test above is not affected.
+describe('ModuleLoader.requireInternal diagnostics', () => {
+  const originalExecArgv = process.execArgv
+  const debugCalls: string[] = []
+
+  beforeEach(() => {
+    debugCalls.length = 0
+    vi.resetModules()
+    vi.spyOn(console, 'debug').mockImplementation((...args: any[]) => {
+      debugCalls.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '))
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    process.execArgv = originalExecArgv
+    vi.doUnmock('node:module')
+    vi.resetModules()
+  })
+
+  it('logs a cordis:loader diagnostic and returns undefined when require fails', async () => {
+    vi.doMock('node:module', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:module')>()
+      return {
+        ...actual,
+        createRequire: () => () => {
+          throw new Error('forced test failure: simulated missing module')
+        },
+      }
+    })
+    const { ModuleLoader: Fresh } = await import('../src')
+    process.execArgv = []
+
+    const result = Fresh.fromInternal()
+    expect(result).toBeUndefined()
+    const sawDiagnostic = debugCalls.some((m) => /cordis:loader/.test(m))
+    expect(sawDiagnostic, `expected cordis:loader diagnostic; got ${JSON.stringify(debugCalls)}`).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

`requireInternal()` swallowed errors in both `--expose-internals` and `node-addon-require-builtin` fallback paths, so callers could only surface a misleading "--expose-internals is required" string even when the real cause was a missing native binding, pnpm isolated layout, or Node version drift.

## Changes

- Log a `cordis:loader:` debug line on each failure path with the module id and error.
- On the `node-addon-require-builtin` fallback, follow up with a hint enumerating the most common real-world causes (pnpm 10+ isolated layout, missing platform binding, Node version drift) and a search link to the issue tracker.
- Preserve the `undefined` contract — HMR can opt out of using internals gracefully.

## Verification

- `vitest run packages/loader/tests/` green, including one new regression test for the silent catch.
- `vitest run packages/hmr/tests/` green — HMR opt-out path unchanged.
