### PR TITLE
fix(include): reconcile file and runtime edits through a journal

### DIFF
--- a/packages/hmr/tests/index.spec.ts
+++ b/packages/hmr/tests/index.spec.ts
@@ -1,9 +1,10 @@
-import { Context, Fiber } from 'cordis'
+import { Context, Fiber, Message } from 'cordis'
 import Loader from '@cordisjs/plugin-loader'
 import Logger from '@cordisjs/plugin-logger-console'
+import type { Include } from '@cordisjs/plugin-include'
 import { writeFileSync, readFileSync, unlinkSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
-import { expect, describe, it, beforeAll, afterAll, afterEach } from 'vitest'
+import { expect, describe, it, beforeAll, afterAll, afterEach, vi } from 'vitest'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
@@ -451,6 +452,86 @@ export function apply(ctx: Context) {
       const value = ctx.bail('hmr-test/get-value')
       expect(value).to.not.equal('initial')
     }, 10000)
+  })
+
+  // ===== Config file atomic writes =====
+  describe('config file atomic writes', () => {
+    let ctx: Context
+    let fiber: Fiber<Context>
+    const configPath = resolve(testDir, 'cordis-atomic.yml')
+    const messages: Message[] = []
+
+    const configWith = (value: string) => `- id: timer
+  name: '@cordisjs/plugin-timer'
+- id: hmr
+  name: '@cordisjs/plugin-hmr'
+  config:
+    root:
+      - .
+    debounce: 50
+- id: cfg
+  name: ./plugin-config
+  config:
+    value: ${value}
+`
+
+    beforeAll(async () => {
+      writeFileSync(configPath, configWith('v0'))
+      const result = await createContext('cordis-atomic.yml')
+      ctx = result.ctx
+      fiber = result.fiber
+      ctx.logger.exporter({ export: message => messages.push(message) })
+    }, 10000)
+
+    afterAll(async () => {
+      await fiber?.dispose()
+      try { unlinkSync(configPath) } catch {}
+    })
+
+    function include() {
+      for (const entry of ctx.loader.entries()) {
+        if ((entry.subtree as Include | undefined)?.filename === configPath) return entry.subtree as Include
+      }
+      throw new Error('include not found')
+    }
+
+    it('keeps watching the file across its own rename-based writes', async () => {
+      const inc = include()
+      const id = ctx.loader.store[inc.ctx.fiber.entry!.options.id]!.id
+      const refresh = vi.spyOn(inc, 'refresh')
+
+      // two runtime writes → two temp-file-plus-rename cycles on the config
+      for (const value of ['v1', 'v2']) {
+        await ctx.loader.update(`${id}:cfg`, { config: { value } })
+        await inc.refresh()
+      }
+      await waitFor(() => readFileSync(configPath, 'utf8').includes('value: v2'))
+      await new Promise(r => setTimeout(r, 500))
+      const settled = refresh.mock.calls.length
+
+      // an external edit must still reach the tree through the watcher
+      const external = configWith('v3')
+      writeFileSync(configPath, external)
+      await waitFor(() => ctx.bail('hmr-test/get-config')?.value === 'v3')
+
+      // and our own writes must not have spawned a feedback loop
+      await new Promise(r => setTimeout(r, 500))
+      expect(refresh.mock.calls.length - settled).toBeLessThanOrEqual(3)
+      expect(readFileSync(configPath, 'utf8')).toBe(external)
+    }, 15000)
+
+    it('logs instead of rejecting when the config file is unparsable', async () => {
+      const before = messages.length
+      writeFileSync(configPath, '- {\n')
+      await waitFor(() => messages.slice(before).some(m => m.type === 'warn' && String(m.args[0]).includes('failed to parse')))
+
+      // hmr is still alive and the tree kept its last good state
+      expect(ctx.hmr).to.be.ok
+      expect(ctx.bail('hmr-test/get-config')?.value).toBe('v3')
+
+      writeFileSync(configPath, configWith('v4'))
+      await waitFor(() => ctx.bail('hmr-test/get-config')?.value === 'v4')
+    }, 15000)
   })
 
   // ===== Service plugin HMR =====

--- a/packages/hmr/tests/plugin-config.ts
+++ b/packages/hmr/tests/plugin-config.ts
@@ -1,0 +1,7 @@
+import { Context } from 'cordis'
+
+export const name = 'plugin-config'
+
+export function apply(ctx: Context, config: any) {
+  ctx.on('hmr-test/get-config', () => config)
+}

--- a/packages/include/src/index.ts
+++ b/packages/include/src/index.ts
@@ -1,9 +1,12 @@
-import { EntryOptions, EntryTree, isJsExpr } from '@cordisjs/plugin-loader'
+import { EntryChange, EntryOptions, EntryTree, isJsExpr } from '@cordisjs/plugin-loader'
 import { Context, Service } from 'cordis'
-import { extname } from 'node:path'
-import { access, constants, readFile, rename, writeFile } from 'node:fs/promises'
+import { deepEqual } from 'cosmokit'
+import { basename, dirname, extname, join } from 'node:path'
+import { access, constants, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import * as yaml from 'js-yaml'
+import { applyJournal, flatten, Journal, merge, reconcile, record } from './journal.ts'
+import { applyPatches, ensureIds, ensureInsertIds, PatchIndex, PatchOptions, routeJournal } from './patch.ts'
 
 const JsExpr = new yaml.Type('tag:yaml.org,2002:js', {
   kind: 'scalar',
@@ -15,25 +18,39 @@ const JsExpr = new yaml.Type('tag:yaml.org,2002:js', {
 
 const schema = yaml.JSON_SCHEMA.extend(JsExpr)
 
-const writable: Record<string, string> = {
+const types: Record<string, string> = {
   '.json': 'application/json',
   '.yaml': 'application/yaml',
   '.yml': 'application/yaml',
 }
 
-const supported = new Set(Object.keys(writable))
+type ConfigStage = 'read' | 'parse' | 'validate'
 
-export interface PatchOptions {
-  id?: string
-  insert?: EntryOptions[]
-  name?: string
-  config?: any
-  group?: boolean | null
-  disabled?: boolean | null
-  inject?: any
-  intercept?: any
-  isolate?: any
-  [key: string]: any
+interface Snapshot {
+  content: string
+  data: EntryOptions[]
+}
+
+export class ConfigFileError extends Error {
+  name = 'ConfigFileError'
+
+  constructor(public stage: ConfigStage, path: string, cause: unknown) {
+    super(`failed to ${stage} config file ${path}`, { cause })
+  }
+}
+
+/** The file changed under us between the pre-check and the rename. */
+class StaleWriteError extends Error {
+  name = 'StaleWriteError'
+}
+
+interface Anonymous {
+  parent: string | null
+  options: EntryOptions
+}
+
+function isENOENT(error: unknown) {
+  return (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT'
 }
 
 export namespace Include {
@@ -49,170 +66,348 @@ export class Include extends EntryTree {
   static inject = ['loader']
 
   public filename: string
-  private type?: string
-  private readonly: boolean
-  private content?: string
-  private data?: EntryOptions[]
-  private writeTask?: NodeJS.Timeout | undefined
+  private type: string
+
+  /** The last file state we read or wrote. */
+  private cache?: Snapshot
+  /** Tree-side changes that have not reached the file yet. */
+  private journal: Journal = new Map()
+  /** Ids we assigned to entries the file leaves anonymous. */
+  private anonymous = new Map<string, Anonymous>()
+
+  private dirtyRead = false
+  private dirtyWrite = false
+  private _draining?: Promise<void>
+
+  /** Only the latest intended tree is ever applied; older ones are skipped. */
+  private _pendingTree?: EntryOptions[]
+  private _applyTask?: Promise<void>
+
+  private _disposed = false
+  private _seq = 0
 
   constructor(ctx: Context, public config: Include.Config) {
     super(ctx)
     this.enableLogs = config.enableLogs ?? ctx.fiber.entry?.parent.tree.enableLogs ?? false
     this.filename = fileURLToPath(new URL(this.config.path, this.ctx.baseUrl))
     const ext = extname(this.filename)
-    if (!supported.has(ext)) {
+    if (!types[ext]) {
       throw new Error(`extension "${ext}" not supported`)
     }
-    this.type = writable[ext]
-    this.readonly = !this.type
+    this.type = types[ext]
     this.ctx.baseUrl = new URL('.', pathToFileURL(this.filename)).href
+    ensureInsertIds(config.patches, id => !!this.store[id])
 
-    ctx.on('internal/update', async (config, _, next) => {
+    ctx.on('internal/update', (config, _, next) => {
       if (config.path !== this.config.path) return next()
-      await this.root.update(this.data!)
+      this.config = config
+      ensureInsertIds(config.patches, id => !!this.store[id])
+      this._scheduleApply()
+      return this._applyTask
     })
   }
 
-  private async checkAccess() {
-    if (!this.type) return
-    try {
-      await access(this.filename, constants.W_OK)
-    } catch {
-      this.readonly = true
-    }
-  }
-
-  private async read(forced = false) {
-    const content = await readFile(this.filename, 'utf8')
-    if (!forced && this.content === content) return false
-    this.content = content
-    if (this.type === 'application/yaml') {
-      this.data = yaml.load(this.content, { schema }) as any
-    } else if (this.type === 'application/json') {
-      this.data = JSON.parse(this.content) as any
-    } else {
-      const module = await import(/* @vite-ignore */ this.filename)
-      this.data = module.default || module
-    }
-    await this.checkAccess()
-    return true
-  }
-
-  private applyPatches(data: EntryOptions[]): EntryOptions[] {
-    const { patches } = this.config
-    if (!patches?.length) return data
-
-    const entryMap = new Map<string, EntryOptions>()
-    const buildMap = (entries: EntryOptions[]) => {
-      for (const entry of entries) {
-        if (entry.id) entryMap.set(entry.id, entry)
-        if (entry.group && Array.isArray(entry.config)) {
-          buildMap(entry.config)
-        }
-      }
-    }
-    buildMap(data)
-
-    for (const patch of patches) {
-      const { id, insert, name, ...overrides } = patch
-
-      if (insert) {
-        if (id) {
-          const target = entryMap.get(id)
-          if (!target) {
-            this.ctx.root.logger?.('loader').warn('patch insert: entry %C not found', id)
-            continue
-          }
-          if (!target.group) {
-            this.ctx.root.logger?.('loader').warn('patch insert: entry %C is not a group', id)
-            continue
-          }
-          if (!Array.isArray(target.config)) target.config = []
-          target.config.push(...insert)
-        } else {
-          data.push(...insert)
-        }
-        continue
-      }
-
-      if (!id) {
-        this.ctx.root.logger?.('loader').warn('patch: id is required for non-insert patches')
-        continue
-      }
-
-      const target = entryMap.get(id)
-      if (!target) {
-        this.ctx.root.logger?.('loader').warn('patch: entry %C not found', id)
-        continue
-      }
-
-      if (name && name !== target.name) {
-        this.ctx.root.logger?.('loader').warn(
-          'patch: name mismatch for %C (expected %C, got %C), skipping',
-          id, target.name, name,
-        )
-        continue
-      }
-
-      for (const [key, value] of Object.entries(overrides)) {
-        if (key === 'id') continue
-        target[key] = value
-      }
-    }
-
-    return data
+  private warn = (format: string, ...args: any[]) => {
+    this.ctx.root.logger?.('loader').warn(format, ...args)
   }
 
   async* [Service.init]() {
     try {
-      await this.read()
-    } catch {
-      if (this.config.initial) {
-        this.writeFile(this.config.initial as any)
-        await this.read()
-      } else {
+      await this._read()
+    } catch (error) {
+      // Only a missing file falls back to `initial`: an existing but invalid
+      // file must fail loud with its real parse error, never be mislabeled as
+      // absent and then silently overwritten.
+      const cause = error instanceof ConfigFileError && error.stage === 'read' ? error.cause : undefined
+      if (!isENOENT(cause)) throw error
+      if (!this.config.initial) {
         throw new Error(`config file not found: ${this.filename}`)
       }
+      const initial = structuredClone(this.config.initial) as EntryOptions[]
+      ensureIds(initial, id => !!this.store[id])
+      await this._writeText(this.dump(initial))
+      await this._read()
     }
 
     yield () => this.stop()
-    const data = this.applyPatches([...this.data!])
-    await this.root.update(data)
+    await this._applyTask
   }
 
-  stop() {
+  async stop() {
+    this._disposed = true
+    this._pendingTree = undefined
+    // flush what the user last did before the tree goes away
+    await this.flush()
     this.root.stop()
   }
 
-  async refresh() {
-    if (!await this.read()) return
-    this.root.update(this.data!)
-  }
-
-  private async _writeFile(config: EntryOptions[]) {
-    if (this.readonly) {
-      throw new Error(`cannot overwrite readonly config`)
+  /**
+   * Resolves once every pending read and write has been processed and the
+   * tree reflects the outcome. Unlike `refresh()`, this does wait for writes.
+   */
+  async flush() {
+    while (this._draining || this._applyTask) {
+      await this._draining
+      await this._applyTask
     }
-    if (this.type === 'application/yaml') {
-      this.content = yaml.dump(config, { schema })
-    } else if (this.type === 'application/json') {
-      this.content = JSON.stringify(config, null, 2)
-    }
-    await writeFile(this.filename + '.tmp', this.content!)
-    await rename(this.filename + '.tmp', this.filename)
   }
 
-  private writeFile(config: EntryOptions[]) {
-    clearTimeout(this.writeTask)
-    this.writeTask = setTimeout(() => {
-      this.writeTask = undefined
-      this._writeFile(config)
-    }, 0)
+  /** Re-read the file and reconcile the tree with it. */
+  refresh() {
+    this.dirtyRead = true
+    this._drain()
+    return this.flush()
   }
 
-  write() {
+  /** Called synchronously by the loader once a tree-side change is in place. */
+  commit(change: EntryChange) {
     this.context.emit('loader/config-update')
-    return this.writeFile(this.root.data)
+    const parent = change.group === this.root ? null : change.group.ctx.fiber.entry!.options.id
+    record(this.journal, change, parent)
+    this.dirtyWrite = true
+    this._drain()
+  }
+
+  private _drain() {
+    if (this._draining) return
+    this._draining = this._loop().finally(() => {
+      this._draining = undefined
+    })
+  }
+
+  private async _loop() {
+    while (this.dirtyRead || this.dirtyWrite) {
+      if (this.dirtyRead) {
+        this.dirtyRead = false
+        try {
+          await this._read()
+        } catch (error) {
+          // Half-written files are routine while the user is editing, hence
+          // only a warning. With the file in an unknown state there is nothing
+          // safe to write: unless another read is due, stop here and leave
+          // `dirtyWrite` set for the next trigger.
+          this.ctx.logger.warn(error)
+          if (this.dirtyRead) continue
+          return
+        }
+      }
+      if (this.dirtyWrite) {
+        this.dirtyWrite = false
+        try {
+          await this._write()
+        } catch (error) {
+          this.ctx.logger.error(error)
+        }
+      }
+    }
+  }
+
+  private async _read() {
+    let content: string
+    try {
+      content = await readFile(this.filename, 'utf8')
+    } catch (error) {
+      throw new ConfigFileError('read', this.filename, error)
+    }
+    if (content === this.cache?.content) return
+
+    let data: any
+    try {
+      data = this.type === 'application/yaml'
+        ? yaml.load(content, { schema })
+        : JSON.parse(content)
+    } catch (error) {
+      throw new ConfigFileError('parse', this.filename, error)
+    }
+    // An empty or truncated file (common mid-edit: editors and `sed -i` write
+    // through temp states) parses to `undefined` rather than throwing, so
+    // every non-array shape is rejected here as one "invalid file" signal.
+    if (!Array.isArray(data)) {
+      throw new ConfigFileError('validate', this.filename, new TypeError('config file must be a top-level array'))
+    }
+
+    this._assignIds(data)
+
+    if (this.cache) {
+      const index = new PatchIndex(this.config.patches ?? [])
+      const conflicts = reconcile(this.journal, flatten(this.cache.data), flatten(data), (id, key) => index.fileOwned(id, key))
+      for (const { id, reason } of conflicts) {
+        this.ctx.logger.error('config conflict in %C: entry %C %s; file wins', this.filename, id, reason)
+      }
+    }
+
+    this.cache = { content, data }
+    this._scheduleApply()
+    // the file changed while tree-side changes were pending: write the merge
+    if (this.journal.size) this.dirtyWrite = true
+  }
+
+  private async _write() {
+    if (!this.cache || !this.journal.size) return
+    const current = await readFile(this.filename, 'utf8').catch((error) => {
+      if (isENOENT(error)) return undefined
+      throw error
+    })
+    if (current === undefined) {
+      this.ctx.logger.warn('config file %C is missing, %d pending change(s) kept in memory', this.filename, this.journal.size)
+      return
+    }
+    if (current !== this.cache.content) {
+      // someone else wrote the file: merge first, then come back
+      this.dirtyRead = true
+      this.dirtyWrite = true
+      return
+    }
+
+    // Snapshot and swap: changes reported while we are writing must survive
+    // into the next round instead of being cleared along with this batch.
+    const batch = this.journal
+    this.journal = new Map()
+    const restore = () => {
+      for (const [id, record] of this.journal) merge(batch, id, record)
+      this.journal = batch
+    }
+
+    const data = structuredClone(this.cache.data)
+    const patches = structuredClone(this.config.patches ?? [])
+    if (routeJournal(batch, data, patches, this.warn)) {
+      // Take the new patches now so that the tree scheduled below already
+      // reflects them; the round trip through the parent only persists them.
+      this.config = { ...this.config, patches }
+      if (this.ctx.fiber.entry) {
+        // Not awaited: the returned promise is the tree reconciliation, and
+        // the drain loop must not block on fibers.
+        try {
+          Promise.resolve(this.ctx.fiber.update(this.config)).catch((error) => {
+            this.ctx.logger.error(error)
+          })
+        } catch (error) {
+          this.ctx.logger.error(error)
+        }
+      } else {
+        this.ctx.logger.warn('patches of %C changed at runtime but cannot be persisted', this.filename)
+      }
+    }
+
+    // nothing for the file itself (patch-only changes, or ids we assigned to
+    // anonymous entries that are already part of the cache)
+    if (deepEqual(data, this.cache.data)) {
+      this._scheduleApply()
+      return
+    }
+    const text = this.dump(data)
+
+    try {
+      await access(this.filename, constants.W_OK)
+    } catch {
+      restore()
+      this.ctx.logger.warn('config file %C is read-only, %d pending change(s) kept in memory', this.filename, this.journal.size)
+      return
+    }
+
+    try {
+      await this._writeText(text, this.cache.content)
+    } catch (error) {
+      restore()
+      if (error instanceof StaleWriteError) {
+        this.dirtyRead = true
+        this.dirtyWrite = true
+        return
+      }
+      this.ctx.logger.warn('failed to write config file %C, %d pending change(s) kept in memory', this.filename, this.journal.size)
+      throw error
+    }
+    this.cache = { content: text, data }
+    this._scheduleApply()
+  }
+
+  /**
+   * Write through a temp file and a rename, so that no reader ever sees a
+   * truncated file. When `expected` is given, the rename is skipped if the
+   * file no longer holds that content.
+   */
+  private async _writeText(text: string, expected?: string) {
+    const tmp = join(dirname(this.filename), `.${basename(this.filename)}.${process.pid}.${this._seq++}.tmp`)
+    try {
+      await writeFile(tmp, text)
+      if (expected !== undefined) {
+        const current = await readFile(this.filename, 'utf8').catch(() => undefined)
+        if (current !== expected) throw new StaleWriteError()
+      }
+      await rename(tmp, this.filename)
+    } catch (error) {
+      await rm(tmp, { force: true }).catch(() => {})
+      throw error
+    }
+  }
+
+  private dump(data: EntryOptions[]) {
+    return this.type === 'application/yaml'
+      ? yaml.dump(data, { schema })
+      : JSON.stringify(data, null, 2)
+  }
+
+  /**
+   * Entries the file leaves anonymous get an id here, before the loader sees
+   * them. One that looks exactly like an entry we named on the previous read
+   * keeps that id, so editing a neighbor does not restart it; anything else
+   * gets a fresh id. Assigned ids stay in memory until the next write.
+   */
+  private _assignIds(data: EntryOptions[]) {
+    const used = new Set<string>()
+    const pending: { options: EntryOptions; parent: string | null }[] = []
+    const walk = (entries: EntryOptions[], parent: string | null) => {
+      for (const options of entries) {
+        if (options.id) {
+          used.add(options.id)
+        } else {
+          pending.push({ options, parent })
+        }
+        if (options.group && Array.isArray(options.config)) {
+          walk(options.config, options.id ?? null)
+        }
+      }
+    }
+    walk(data, null)
+
+    const previous = this.anonymous
+    this.anonymous = new Map()
+    for (const { options, parent } of pending) {
+      let id: string | undefined
+      for (const [candidate, info] of previous) {
+        if (info.parent !== parent || !deepEqual(info.options, options)) continue
+        id = candidate
+        previous.delete(candidate)
+        break
+      }
+      if (!id) {
+        do {
+          id = Math.random().toString(16).slice(2, 10)
+        } while (used.has(id) || this.store[id])
+      }
+      used.add(id)
+      this.anonymous.set(id, { parent, options: structuredClone(options) })
+      const rest = { ...options }
+      for (const key of Object.keys(options)) delete options[key]
+      Object.assign(options, { id }, rest)
+    }
+  }
+
+  private _scheduleApply() {
+    if (this._disposed || !this.cache) return
+    const tree = applyPatches(this.cache.data, this.config.patches, this.warn)
+    this._pendingTree = applyJournal(tree, this.journal, undefined, this.warn)
+    this._applyTask ??= (async () => {
+      try {
+        while (this._pendingTree) {
+          const tree = this._pendingTree
+          this._pendingTree = undefined
+          await this.root.update(tree)
+        }
+      } finally {
+        this._applyTask = undefined
+      }
+    })()
   }
 }
 

--- a/packages/include/src/index.ts
+++ b/packages/include/src/index.ts
@@ -3,6 +3,7 @@ import { Context, Service } from 'cordis'
 import { deepEqual } from 'cosmokit'
 import { basename, dirname, extname, join } from 'node:path'
 import { access, constants, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { setTimeout as sleep } from 'node:timers/promises'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import * as yaml from 'js-yaml'
 import { applyJournal, flatten, Journal, merge, reconcile, record } from './journal.ts'
@@ -51,6 +52,20 @@ interface Anonymous {
 
 function isENOENT(error: unknown) {
   return (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT'
+}
+
+const RENAME_RETRIES = 10
+const RENAME_BACKOFF = 20
+
+/**
+ * On Windows a rename over a file that another process holds open (typically
+ * an antivirus scanning what we just wrote) fails with one of these; the lock
+ * is normally gone within milliseconds. A bounded retry is cheap enough to
+ * apply on every platform.
+ */
+function isTransientRenameError(error: unknown) {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code
+  return code === 'EACCES' || code === 'EPERM' || code === 'EBUSY'
 }
 
 export namespace Include {
@@ -115,9 +130,7 @@ export class Include extends EntryTree {
     try {
       await this._read()
     } catch (error) {
-      // Only a missing file falls back to `initial`: an existing but invalid
-      // file must fail loud with its real parse error, never be mislabeled as
-      // absent and then silently overwritten.
+      // only a missing file falls back to `initial`
       const cause = error instanceof ConfigFileError && error.stage === 'read' ? error.cause : undefined
       if (!isENOENT(cause)) throw error
       if (!this.config.initial) {
@@ -136,7 +149,12 @@ export class Include extends EntryTree {
   async stop() {
     this._disposed = true
     this._pendingTree = undefined
-    // flush what the user last did before the tree goes away
+    // Flush what the user last did before the tree goes away; this is also the
+    // last attempt for changes a failed write left in the journal.
+    if (this.journal.size) {
+      this.dirtyWrite = true
+      this._drain()
+    }
     await this.flush()
     this.root.stop()
   }
@@ -219,8 +237,7 @@ export class Include extends EntryTree {
     } catch (error) {
       throw new ConfigFileError('parse', this.filename, error)
     }
-    // An empty or truncated file (common mid-edit: editors and `sed -i` write
-    // through temp states) parses to `undefined` rather than throwing, so
+    // An empty or truncated file (routine mid-edit) parses to `undefined`, so
     // every non-array shape is rejected here as one "invalid file" signal.
     if (!Array.isArray(data)) {
       throw new ConfigFileError('validate', this.filename, new TypeError('config file must be a top-level array'))
@@ -259,8 +276,8 @@ export class Include extends EntryTree {
       return
     }
 
-    // Snapshot and swap: changes reported while we are writing must survive
-    // into the next round instead of being cleared along with this batch.
+    // Snapshot and swap: changes reported while we are writing belong to the
+    // next round.
     const batch = this.journal
     this.journal = new Map()
     const restore = () => {
@@ -323,18 +340,26 @@ export class Include extends EntryTree {
 
   /**
    * Write through a temp file and a rename, so that no reader ever sees a
-   * truncated file. When `expected` is given, the rename is skipped if the
-   * file no longer holds that content.
+   * truncated file. When `expected` is given, the rename (and every retry of
+   * it) only goes ahead while the file still holds that content.
    */
   private async _writeText(text: string, expected?: string) {
     const tmp = join(dirname(this.filename), `.${basename(this.filename)}.${process.pid}.${this._seq++}.tmp`)
     try {
       await writeFile(tmp, text)
-      if (expected !== undefined) {
-        const current = await readFile(this.filename, 'utf8').catch(() => undefined)
-        if (current !== expected) throw new StaleWriteError()
+      for (let attempt = 0; ; attempt++) {
+        if (expected !== undefined) {
+          const current = await readFile(this.filename, 'utf8').catch(() => undefined)
+          if (current !== expected) throw new StaleWriteError()
+        }
+        try {
+          await rename(tmp, this.filename)
+          return
+        } catch (error) {
+          if (attempt >= RENAME_RETRIES || !isTransientRenameError(error)) throw error
+        }
+        await sleep(RENAME_BACKOFF * (attempt + 1))
       }
-      await rename(tmp, this.filename)
     } catch (error) {
       await rm(tmp, { force: true }).catch(() => {})
       throw error

--- a/packages/include/src/journal.ts
+++ b/packages/include/src/journal.ts
@@ -1,0 +1,243 @@
+import { EntryChange, EntryOptions } from '@cordisjs/plugin-loader'
+import { deepEqual, Dict, omit } from 'cosmokit'
+
+/** One tree-side mutation that has not reached the file yet, keyed by entry id. */
+export type JournalRecord = JournalRecord.Remove | JournalRecord.Upsert
+
+export namespace JournalRecord {
+  export interface Remove {
+    kind: 'remove'
+  }
+
+  export interface Upsert {
+    kind: 'upsert'
+    /** The entry did not exist when the tree first reported it. */
+    created: boolean
+    /**
+     * The group the tree placed the entry in (`null` for the root), or
+     * `undefined` when the tree did not relocate it.
+     */
+    parent: string | null | undefined
+    /** Index within `parent`; only meaningful alongside a `parent`. */
+    position: number
+    /**
+     * Per-key delta relative to the options the entry had when the change
+     * was reported; `undefined` deletes a key. Collected at report time and
+     * never derived from the live tree later, because the tree is reconciled
+     * asynchronously and may lag behind the file.
+     */
+    changes: Dict
+  }
+}
+
+export type Journal = Map<string, JournalRecord>
+
+export function diffOptions(legacy: EntryOptions, options: EntryOptions) {
+  const changes: Dict = {}
+  for (const key of new Set([...Object.keys(legacy), ...Object.keys(options)])) {
+    if (key === 'id') continue
+    if (deepEqual(legacy[key], options[key])) continue
+    changes[key] = options[key]
+  }
+  return changes
+}
+
+/** Fold a later record into an earlier one for the same entry. */
+export function mergeRecords(older: JournalRecord | undefined, newer: JournalRecord): JournalRecord | undefined {
+  if (!older) return newer
+  if (newer.kind === 'remove') {
+    // an entry created and removed before ever being written leaves no trace
+    return older.kind === 'upsert' && older.created ? undefined : newer
+  }
+  if (older.kind === 'remove') {
+    return { ...newer, created: false }
+  }
+  const relocated = newer.parent !== undefined
+  return {
+    kind: 'upsert',
+    created: older.created,
+    parent: relocated ? newer.parent : older.parent,
+    position: relocated ? newer.position : older.position,
+    changes: { ...older.changes, ...newer.changes },
+  }
+}
+
+export function merge(journal: Journal, id: string, record: JournalRecord) {
+  const merged = mergeRecords(journal.get(id), record)
+  if (merged) {
+    journal.set(id, merged)
+  } else {
+    journal.delete(id)
+  }
+}
+
+export function record(journal: Journal, change: EntryChange, parent: string | null) {
+  const { id, options, legacy } = change
+  if (!options) {
+    return merge(journal, id, { kind: 'remove' })
+  }
+  const position = change.group.data.indexOf(options)
+  if (!legacy) {
+    return merge(journal, id, { kind: 'upsert', created: true, parent, position, changes: omit(options, ['id']) })
+  }
+  merge(journal, id, {
+    kind: 'upsert',
+    created: false,
+    parent: change.from ? parent : undefined,
+    position,
+    changes: diffOptions(legacy, options),
+  })
+}
+
+export interface FlatEntry {
+  parent: string | null
+  position: number
+  options: EntryOptions
+  list: EntryOptions[]
+}
+
+/** Index every entry (including nested group members) by id. */
+export function flatten(data: EntryOptions[], parent: string | null = null, result = new Map<string, FlatEntry>()) {
+  data.forEach((options, position) => {
+    if (options.id) result.set(options.id, { parent, position, options, list: data })
+    if (options.group && Array.isArray(options.config)) {
+      flatten(options.config, options.id ?? null, result)
+    }
+  })
+  return result
+}
+
+export function applyChanges(options: EntryOptions, changes: Dict, filter?: (key: string) => boolean) {
+  for (const [key, value] of Object.entries(changes)) {
+    if (filter && !filter(key)) continue
+    if (value === undefined) {
+      delete options[key]
+    } else {
+      options[key] = value
+    }
+  }
+}
+
+export function detach(data: EntryOptions[], id: string) {
+  const flat = flatten(data).get(id)
+  if (!flat) return
+  flat.list.splice(flat.list.indexOf(flat.options), 1)
+  return flat.options
+}
+
+/**
+ * Insert `options` under `parent` (a group id, or `null` for the root) at
+ * `position`, clamped to the group's length. Returns false when the parent
+ * group does not exist.
+ */
+export function place(data: EntryOptions[], options: EntryOptions, parent: string | null, position: number) {
+  let list = data
+  if (parent !== null) {
+    const group = flatten(data).get(parent)
+    if (!group?.options.group) return false
+    list = group.options.config ??= []
+  }
+  list.splice(Math.min(position, list.length), 0, options)
+  return true
+}
+
+/**
+ * Overlay a journal onto `data` in place. `filter(id, key)` restricts which
+ * changes apply; `key` is `null` when asking about the entry as a whole
+ * (creation, removal, relocation).
+ */
+export function applyJournal(
+  data: EntryOptions[],
+  journal: Journal,
+  filter: (id: string, key: string | null) => boolean = () => true,
+  warn: (format: string, ...args: any[]) => void = () => {},
+) {
+  for (const [id, record] of journal) {
+    if (!filter(id, null)) continue
+    if (record.kind === 'remove') {
+      detach(data, id)
+      continue
+    }
+    const flat = flatten(data).get(id)
+    if (!flat) {
+      const options = { id } as EntryOptions
+      applyChanges(options, record.changes, key => filter(id, key))
+      const parent = record.parent ?? null
+      if (!place(data, options, parent, record.position)) {
+        warn('cannot place entry %C: group %C not found', id, parent)
+      }
+      continue
+    }
+    applyChanges(flat.options, record.changes, key => filter(id, key))
+    if (record.parent !== undefined && flat.parent !== record.parent) {
+      detach(data, id)
+      if (!place(data, flat.options, record.parent, record.position)) {
+        warn('cannot move entry %C: group %C not found', id, record.parent)
+        place(data, flat.options, flat.parent, flat.position)
+      }
+    }
+  }
+  return data
+}
+
+export interface Conflict {
+  id: string
+  reason: string
+}
+
+/**
+ * Three-way reconciliation of a journal against a new file state. The file
+ * wins every conflict: conflicting keys are dropped from the journal so that
+ * the tree follows the file, and each drop is reported.
+ *
+ * `fileOwned(id, key)` scopes the check to what the file can actually express
+ * (patch-owned keys and patch-inserted entries live elsewhere).
+ */
+export function reconcile(
+  journal: Journal,
+  base: Map<string, FlatEntry>,
+  theirs: Map<string, FlatEntry>,
+  fileOwned: (id: string, key: string | null) => boolean,
+) {
+  const conflicts: Conflict[] = []
+  for (const [id, record] of journal) {
+    if (!fileOwned(id, null)) continue
+    const b = base.get(id)
+    const t = theirs.get(id)
+    if (record.kind === 'remove') {
+      if (!t) {
+        journal.delete(id)
+      } else if (!b || !deepEqual(t.options, b.options)) {
+        conflicts.push({ id, reason: b ? 'modified in file, removed at runtime' : 'added in file, removed at runtime' })
+        journal.delete(id)
+      }
+      continue
+    }
+    if (!t) {
+      if (b) {
+        conflicts.push({ id, reason: 'removed in file, modified at runtime' })
+        journal.delete(id)
+      }
+      // else: created at runtime, nothing in the file to conflict with
+      continue
+    }
+    if (record.created) record.created = false
+    for (const key of Object.keys(record.changes)) {
+      if (!fileOwned(id, key)) continue
+      const bv = b?.options[key]
+      const tv = t.options[key]
+      if (deepEqual(bv, tv) || deepEqual(tv, record.changes[key])) continue
+      conflicts.push({ id, reason: `key "${key}" modified both in file and at runtime` })
+      delete record.changes[key]
+    }
+    if (record.parent !== undefined && b && t.parent !== b.parent && t.parent !== record.parent) {
+      conflicts.push({ id, reason: 'moved both in file and at runtime' })
+      record.parent = undefined
+    }
+    const moved = record.parent !== undefined && record.parent !== t.parent
+    if (!Object.keys(record.changes).length && !moved) {
+      journal.delete(id)
+    }
+  }
+  return conflicts
+}

--- a/packages/include/src/journal.ts
+++ b/packages/include/src/journal.ts
@@ -22,9 +22,8 @@ export namespace JournalRecord {
     position: number
     /**
      * Per-key delta relative to the options the entry had when the change
-     * was reported; `undefined` deletes a key. Collected at report time and
-     * never derived from the live tree later, because the tree is reconciled
-     * asynchronously and may lag behind the file.
+     * was reported; `undefined` deletes a key. Collected at report time: the
+     * live tree is reconciled asynchronously and may lag behind the file.
      */
     changes: Dict
   }

--- a/packages/include/src/patch.ts
+++ b/packages/include/src/patch.ts
@@ -1,0 +1,264 @@
+import { EntryOptions } from '@cordisjs/plugin-loader'
+import { Dict, omit } from 'cosmokit'
+import { applyChanges, detach, flatten, Journal, place } from './journal.ts'
+
+export interface PatchOptions {
+  id?: string
+  insert?: EntryOptions[]
+  name?: string
+  config?: any
+  group?: boolean | null
+  disabled?: boolean | null
+  inject?: any
+  intercept?: any
+  isolate?: any
+  [key: string]: any
+}
+
+export type Warn = (format: string, ...args: any[]) => void
+
+function randomId(used: (id: string) => boolean) {
+  let id: string
+  do {
+    id = Math.random().toString(16).slice(2, 10)
+  } while (used(id))
+  return id
+}
+
+/** Give every entry (nested groups included) an id, in place. */
+export function ensureIds(entries: EntryOptions[], used: (id: string) => boolean) {
+  for (const entry of entries) {
+    if (!entry.id) entry.id = randomId(used)
+    if (entry.group && Array.isArray(entry.config)) ensureIds(entry.config, used)
+  }
+}
+
+/**
+ * Inserted entries are addressed by id when runtime changes are routed back
+ * to their patch, so anonymous inserts would be unreachable otherwise.
+ */
+export function ensureInsertIds(patches: PatchOptions[] | undefined, used: (id: string) => boolean) {
+  for (const patch of patches ?? []) {
+    if (patch.insert) ensureIds(patch.insert, used)
+  }
+}
+
+/**
+ * Overlay `patches` onto a fresh clone of `data`. Inserted entries are cloned
+ * too, so the tree never shares objects with the patch configuration.
+ */
+export function applyPatches(data: EntryOptions[], patches: PatchOptions[] | undefined, warn: Warn): EntryOptions[] {
+  data = structuredClone(data)
+  if (!patches?.length) return data
+
+  const entryMap = new Map<string, EntryOptions>()
+  const buildMap = (entries: EntryOptions[]) => {
+    for (const entry of entries) {
+      if (entry.id) entryMap.set(entry.id, entry)
+      if (entry.group && Array.isArray(entry.config)) {
+        buildMap(entry.config)
+      }
+    }
+  }
+  buildMap(data)
+
+  for (const patch of patches) {
+    const { id, insert, name, ...overrides } = patch
+
+    if (insert) {
+      const clone = structuredClone(insert)
+      if (id) {
+        const target = entryMap.get(id)
+        if (!target) {
+          warn('patch insert: entry %C not found', id)
+          continue
+        }
+        if (!target.group) {
+          warn('patch insert: entry %C is not a group', id)
+          continue
+        }
+        if (!Array.isArray(target.config)) target.config = []
+        target.config.push(...clone)
+      } else {
+        data.push(...clone)
+      }
+      buildMap(clone)
+      continue
+    }
+
+    if (!id) {
+      warn('patch: id is required for non-insert patches')
+      continue
+    }
+
+    const target = entryMap.get(id)
+    if (!target) {
+      warn('patch: entry %C not found', id)
+      continue
+    }
+
+    if (name && name !== target.name) {
+      warn('patch: name mismatch for %C (expected %C, got %C), skipping', id, target.name, name)
+      continue
+    }
+
+    for (const [key, value] of Object.entries(overrides)) {
+      if (key === 'id') continue
+      target[key] = value
+    }
+  }
+
+  return data
+}
+
+/**
+ * Who owns an entry, or one key of it, in the patched tree: the file, a patch
+ * that overrides that key (the last one wins), or the patch that inserted the
+ * whole entry.
+ */
+export type EntryOwner = EntryOwner.File | EntryOwner.Patch | EntryOwner.Insert
+
+export namespace EntryOwner {
+  export interface File {
+    type: 'file'
+  }
+
+  export interface Patch {
+    type: 'patch'
+    /** Index into the patch list. */
+    index: number
+  }
+
+  export interface Insert {
+    type: 'insert'
+    /** Index into the patch list. */
+    index: number
+    /** The insert list (or nested group config) holding the entry. */
+    list: EntryOptions[]
+    options: EntryOptions
+    /** The group the entry is inserted into (`null` for the root). */
+    parent: string | null
+  }
+}
+
+export class PatchIndex {
+  private keys = new Map<string, Map<string, number>>()
+  private inserts = new Map<string, EntryOwner.Insert>()
+
+  constructor(public patches: PatchOptions[]) {
+    patches.forEach((patch, index) => {
+      const { id, insert } = patch
+      if (insert) {
+        const walk = (list: EntryOptions[], parent: string | null) => {
+          for (const options of list) {
+            this.inserts.set(options.id, { type: 'insert', index, list, options, parent })
+            if (options.group && Array.isArray(options.config)) walk(options.config, options.id)
+          }
+        }
+        walk(insert, id ?? null)
+        return
+      }
+      if (!id) return
+      const keys = this.keys.get(id) ?? new Map<string, number>()
+      for (const key of Object.keys(omit(patch, ['id', 'insert', 'name']))) {
+        keys.set(key, index)
+      }
+      this.keys.set(id, keys)
+    })
+  }
+
+  /** Owner of the entry as a whole. */
+  entry(id: string | null): EntryOwner {
+    if (id === null) return { type: 'file' }
+    return this.inserts.get(id) ?? { type: 'file' }
+  }
+
+  /** Owner of one key of an entry. */
+  key(id: string, key: string): EntryOwner {
+    const insert = this.inserts.get(id)
+    if (insert) return insert
+    const index = this.keys.get(id)?.get(key)
+    return index === undefined ? { type: 'file' } : { type: 'patch', index }
+  }
+
+  fileOwned(id: string, key: string | null) {
+    return (key === null ? this.entry(id) : this.key(id, key)).type === 'file'
+  }
+}
+
+/**
+ * Route a journal to its owners: file-owned changes are applied to `data`,
+ * patch-owned ones to `patches`. Both are mutated in place, so pass clones.
+ * Returns whether any patch changed.
+ */
+export function routeJournal(journal: Journal, data: EntryOptions[], patches: PatchOptions[], warn: Warn) {
+  const index = new PatchIndex(patches)
+  let patched = false
+
+  const insertList = (owner: EntryOwner.Insert) => owner.options.config ??= []
+
+  const placeAt = (options: EntryOptions, parent: string | null, position: number) => {
+    const owner = index.entry(parent)
+    if (owner.type === 'insert') {
+      const list = insertList(owner)
+      list.splice(Math.min(position, list.length), 0, options)
+      patched = true
+    } else if (!place(data, options, parent, position)) {
+      warn('cannot place entry %C: group %C not found', options.id, parent)
+    }
+  }
+
+  for (const [id, record] of journal) {
+    const owner = index.entry(id)
+    if (record.kind === 'remove') {
+      if (owner.type === 'insert') {
+        owner.list.splice(owner.list.indexOf(owner.options), 1)
+        patched = true
+      } else {
+        detach(data, id)
+      }
+      continue
+    }
+
+    const current = owner.type === 'insert' ? owner : flatten(data).get(id)
+    if (!current) {
+      const options = { id } as EntryOptions
+      applyChanges(options, record.changes)
+      placeAt(options, record.parent ?? null, record.position)
+      continue
+    }
+
+    if (record.parent !== undefined && current.parent !== record.parent) {
+      // moving across owners: carry the full options over
+      if (owner.type === 'insert') {
+        owner.list.splice(owner.list.indexOf(owner.options), 1)
+        patched = true
+      } else {
+        detach(data, id)
+      }
+      applyChanges(current.options, record.changes)
+      placeAt(current.options, record.parent, record.position)
+      continue
+    }
+
+    if (owner.type === 'insert') {
+      applyChanges(current.options, record.changes)
+      patched = true
+      continue
+    }
+
+    const patchChanges: Dict<Dict> = {}
+    applyChanges(current.options, record.changes, (key) => {
+      const keyOwner = index.key(id, key)
+      if (keyOwner.type !== 'patch') return true
+      ;(patchChanges[keyOwner.index] ??= {})[key] = record.changes[key]
+      return false
+    })
+    for (const [i, changes] of Object.entries(patchChanges)) {
+      applyChanges(patches[i] as any, changes)
+      patched = true
+    }
+  }
+
+  return patched
+}

--- a/packages/include/src/patch.ts
+++ b/packages/include/src/patch.ts
@@ -33,10 +33,7 @@ export function ensureIds(entries: EntryOptions[], used: (id: string) => boolean
   }
 }
 
-/**
- * Inserted entries are addressed by id when runtime changes are routed back
- * to their patch, so anonymous inserts would be unreachable otherwise.
- */
+/** Runtime changes are routed back to an inserted entry by its id, so every insert needs one. */
 export function ensureInsertIds(patches: PatchOptions[] | undefined, used: (id: string) => boolean) {
   for (const patch of patches ?? []) {
     if (patch.insert) ensureIds(patch.insert, used)
@@ -45,7 +42,7 @@ export function ensureInsertIds(patches: PatchOptions[] | undefined, used: (id: 
 
 /**
  * Overlay `patches` onto a fresh clone of `data`. Inserted entries are cloned
- * too, so the tree never shares objects with the patch configuration.
+ * too, so the tree owns every object it mounts.
  */
 export function applyPatches(data: EntryOptions[], patches: PatchOptions[] | undefined, warn: Warn): EntryOptions[] {
   data = structuredClone(data)

--- a/packages/include/tests/fixtures/config-plugin.ts
+++ b/packages/include/tests/fixtures/config-plugin.ts
@@ -1,0 +1,11 @@
+import { Context } from 'cordis'
+
+export const name = 'config-plugin'
+
+/** Tags of every apply, in order, so tests can count restarts. */
+export const applied: string[] = []
+
+export function apply(ctx: Context, config: any) {
+  applied.push(config.tag)
+  ctx.on('test/config', (tag: string) => tag === config.tag ? config : undefined)
+}

--- a/packages/include/tests/patch.spec.ts
+++ b/packages/include/tests/patch.spec.ts
@@ -17,8 +17,7 @@ describe('Include patches', () => {
   let fiber: Fiber<Context>
 
   afterEach(async () => {
-    fiber?.dispose()
-    await new Promise(r => setTimeout(r, 200))
+    await fiber?.dispose()
   })
 
   it('should load without patches', async () => {
@@ -219,6 +218,27 @@ describe('Include patches', () => {
     // inner disabled, extra loaded
     expect(ctx.bail('test/get-value')).to.be.undefined
     expect(ctx.bail('test/get-extra')).to.equal('extra')
+  }, 10000)
+
+  it('should let a later patch address a row inserted by an earlier patch', async () => {
+    ctx = new Context()
+    await ctx.plugin(LoggerConsole)
+    fiber = await ctx.plugin(Loader, {
+      baseUrl: import.meta.url,
+    })
+    await ctx.loader.create({
+      name: '@cordisjs/plugin-include',
+      config: {
+        path: './fixtures/base.yml',
+        patches: [
+          { insert: [{ id: 'added', name: './extra-plugin' }] },
+          { id: 'added', disabled: true },
+        ],
+      },
+    })
+    await waitFor(() => ctx.bail('test/get-value'))
+    // inserted rows are indexed as they land, so the second patch finds `added`
+    expect(ctx.bail('test/get-extra')).to.be.undefined
   }, 10000)
 
   it('should validate name consistency (matching name is ok)', async () => {

--- a/packages/include/tests/reload.spec.ts
+++ b/packages/include/tests/reload.spec.ts
@@ -1,0 +1,137 @@
+import { Context, Fiber, Message } from 'cordis'
+import Loader from '@cordisjs/plugin-loader'
+import LoggerConsole from '@cordisjs/plugin-logger-console'
+import { expect, describe, it, afterEach } from 'vitest'
+import { readFile, rm, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import Include from '../src'
+
+function waitFor(condFn: () => any, timeout = 5000, interval = 20): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const check = setInterval(() => {
+      if (condFn()) { clearInterval(check); resolve() }
+    }, interval)
+    setTimeout(() => { clearInterval(check); reject(new Error('waitFor timed out')) }, timeout)
+  })
+}
+
+const INNER = '- id: inner\n  name: ./test-plugin\n'
+const INNER_EXTRA = '- id: inner\n  name: ./test-plugin\n- id: extra\n  name: ./extra-plugin\n'
+const NOT_AN_ARRAY = 'inner: ./test-plugin\n'
+const UNPARSABLE = '- {\n'
+
+interface Harness {
+  ctx: Context
+  filename: string
+  include(): Include
+  warnings(): string[]
+}
+
+describe('Include reload', () => {
+  let ctx: Context | undefined
+  let fiber: Fiber<Context> | undefined
+  let filename: string | undefined
+
+  afterEach(async () => {
+    await fiber?.dispose()
+    if (filename) await rm(filename, { force: true })
+    ctx = fiber = filename = undefined
+  })
+
+  async function setup(name: string, content: string, config: any = {}): Promise<Harness> {
+    filename = fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url))
+    await writeFile(filename, content)
+    ctx = new Context()
+    await ctx.plugin(LoggerConsole)
+    const messages: Message[] = []
+    ctx.logger.exporter({ export: message => messages.push(message) })
+    fiber = await ctx.plugin(Loader, {
+      baseUrl: import.meta.url,
+    })
+    const id = await ctx.loader.create({
+      name: '@cordisjs/plugin-include',
+      config: {
+        path: `./fixtures/${name}`,
+        ...config,
+      },
+    })
+    return {
+      ctx: ctx!,
+      filename: filename!,
+      include: () => ctx!.loader.store[id]!.subtree as Include,
+      warnings: () => messages.filter(m => m.type === 'warn').map(m => m.args.join(' ')),
+    }
+  }
+
+  it('re-applies patches on every reload', async () => {
+    const app = await setup('tmp-reload-patches.yml', INNER, {
+      patches: [
+        { id: 'inner', disabled: true },
+      ],
+    })
+    await new Promise(r => setTimeout(r, 500))
+    expect(app.ctx.bail('test/get-value')).to.be.undefined
+
+    await writeFile(app.filename, INNER_EXTRA)
+    await app.include().refresh()
+
+    // the new entry loads, and the overlay is applied to the new parse too:
+    // a reload must not silently drop the patch list
+    await waitFor(() => app.ctx.bail('test/get-extra'))
+    expect(app.ctx.bail('test/get-value')).to.be.undefined
+  }, 10000)
+
+  it('reverts an entry when its patch is removed', async () => {
+    const app = await setup('tmp-reload-revert.yml', INNER, {
+      patches: [
+        { id: 'inner', disabled: true },
+      ],
+    })
+    await new Promise(r => setTimeout(r, 500))
+    expect(app.ctx.bail('test/get-value')).to.be.undefined
+
+    // patches apply to a clone: had the overlay been written into the cached
+    // parse, dropping it here could never bring the entry back
+    await app.ctx.loader.update(app.include().ctx.fiber.entry!.id, {
+      config: {
+        path: './fixtures/tmp-reload-revert.yml',
+      },
+    })
+
+    await waitFor(() => app.ctx.bail('test/get-value'))
+    expect(app.ctx.bail('test/get-value')).to.equal('default')
+  }, 10000)
+
+  it('keeps the tree reloadable after an invalid file', async () => {
+    const app = await setup('tmp-reload-invalid.yml', INNER)
+    await waitFor(() => app.ctx.bail('test/get-value'))
+
+    await writeFile(app.filename, NOT_AN_ARRAY)
+    // refresh never rejects: the include reports the bad file itself so that
+    // hmr needs no error handling
+    await app.include().refresh()
+    expect(app.warnings().some(line => line.includes('failed to validate config file'))).to.be.true
+    expect(app.ctx.bail('test/get-value')).to.equal('default')
+
+    // the failed candidate never committed, so the next good file still reads
+    // as a change and reconciles against an intact tree
+    await writeFile(app.filename, INNER_EXTRA)
+    await app.include().refresh()
+    await waitFor(() => app.ctx.bail('test/get-extra'))
+    expect(app.ctx.bail('test/get-value')).to.equal('default')
+  }, 10000)
+
+  it('never overwrites an existing but unparsable file with initial', async () => {
+    const app = await setup('tmp-reload-initial.yml', UNPARSABLE, {
+      initial: [
+        { id: 'extra', name: './extra-plugin' },
+      ],
+    })
+    await new Promise(r => setTimeout(r, 500))
+
+    // only ENOENT falls back to `initial`; a file we failed to parse belongs to
+    // the user and must survive
+    expect(await readFile(app.filename, 'utf8')).to.equal(UNPARSABLE)
+    expect(app.ctx.bail('test/get-extra')).to.be.undefined
+  }, 10000)
+})

--- a/packages/include/tests/reload.spec.ts
+++ b/packages/include/tests/reload.spec.ts
@@ -75,8 +75,7 @@ describe('Include reload', () => {
     await writeFile(app.filename, INNER_EXTRA)
     await app.include().refresh()
 
-    // the new entry loads, and the overlay is applied to the new parse too:
-    // a reload must not silently drop the patch list
+    // the new entry loads, and the overlay is applied to the new parse too
     await waitFor(() => app.ctx.bail('test/get-extra'))
     expect(app.ctx.bail('test/get-value')).to.be.undefined
   }, 10000)
@@ -90,8 +89,7 @@ describe('Include reload', () => {
     await new Promise(r => setTimeout(r, 500))
     expect(app.ctx.bail('test/get-value')).to.be.undefined
 
-    // patches apply to a clone: had the overlay been written into the cached
-    // parse, dropping it here could never bring the entry back
+    // patches apply to a clone of the cached parse, so dropping one reverts the entry
     await app.ctx.loader.update(app.include().ctx.fiber.entry!.id, {
       config: {
         path: './fixtures/tmp-reload-revert.yml',
@@ -107,13 +105,12 @@ describe('Include reload', () => {
     await waitFor(() => app.ctx.bail('test/get-value'))
 
     await writeFile(app.filename, NOT_AN_ARRAY)
-    // refresh never rejects: the include reports the bad file itself so that
-    // hmr needs no error handling
+    // refresh resolves on a bad file; the include reports it itself
     await app.include().refresh()
     expect(app.warnings().some(line => line.includes('failed to validate config file'))).to.be.true
     expect(app.ctx.bail('test/get-value')).to.equal('default')
 
-    // the failed candidate never committed, so the next good file still reads
+    // the cache still holds the last good file, so the next good file reads
     // as a change and reconciles against an intact tree
     await writeFile(app.filename, INNER_EXTRA)
     await app.include().refresh()

--- a/packages/include/tests/sync.spec.ts
+++ b/packages/include/tests/sync.spec.ts
@@ -1,0 +1,342 @@
+import { Context, Fiber, Message } from 'cordis'
+import Loader from '@cordisjs/plugin-loader'
+import { expect, describe, it, afterEach } from 'vitest'
+import { chmod, readFile, rm, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import * as yaml from 'js-yaml'
+import Include from '../src'
+import { applied } from './fixtures/config-plugin'
+
+const fixture = (name: string) => fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url))
+
+const plugin = (id: string, value: number, extra: any = {}) => ({
+  id,
+  name: './config-plugin',
+  config: { tag: id, value },
+  ...extra,
+})
+
+const group = (id: string, config: any[]) => ({
+  id,
+  name: '@cordisjs/plugin-group',
+  group: true,
+  config,
+})
+
+describe('Include sync', () => {
+  let ctx: Context | undefined
+  let fiber: Fiber<Context> | undefined
+  const files: string[] = []
+
+  afterEach(async () => {
+    await fiber?.dispose()
+    ctx = fiber = undefined
+    for (const file of files.splice(0)) {
+      await chmod(file, 0o644).catch(() => {})
+      await rm(file, { force: true })
+    }
+  })
+
+  async function setup(name: string, data: any[] | string, config: any = {}) {
+    const filename = fixture(name)
+    files.push(filename)
+    await writeFile(filename, typeof data === 'string' ? data : yaml.dump(data))
+
+    ctx = new Context()
+    const messages: Message[] = []
+    ctx.logger.exporter({ export: message => messages.push(message) })
+    fiber = await ctx.plugin(Loader, { baseUrl: import.meta.url })
+    const id = await ctx.loader.create({
+      name: '@cordisjs/plugin-include',
+      config: { path: `./fixtures/${name}`, ...config },
+    })
+    await ctx.loader.store[id]!.fiber!.await()
+
+    const include = () => ctx!.loader.store[id]!.subtree as Include
+    // what hmr does on a change event; `refresh` also waits for any write
+    const settle = async () => {
+      await include().refresh()
+      await ctx!.loader.await()
+    }
+    await settle()
+
+    return {
+      ctx: ctx!,
+      id,
+      filename,
+      include,
+      settle,
+      messages,
+      text: () => readFile(filename, 'utf8'),
+      read: async () => yaml.load(await readFile(filename, 'utf8')) as any[],
+      config: (tag: string) => ctx!.bail('test/config', tag),
+      logs: (type: Message['type']) => messages.filter(m => m.type === type).map(m => m.args.join(' ')),
+      update: (local: string, options: any) => ctx!.loader.update(`${id}:${local}`, options),
+    }
+  }
+
+  it('coalesces consecutive writes into the latest state', async () => {
+    const app = await setup('tmp-sync-coalesce.yml', [plugin('a', 1)])
+
+    for (const value of [2, 3, 4]) {
+      await app.update('a', { config: { tag: 'a', value } })
+    }
+    await app.settle()
+
+    expect(app.config('a').value).toBe(4)
+    expect((await app.read())[0].config.value).toBe(4)
+    expect(app.logs('error')).toEqual([])
+  }, 10000)
+
+  it('keeps file and tree consistent when a refresh lands inside a write', async () => {
+    const app = await setup('tmp-sync-window.yml', [plugin('a', 1)])
+
+    const update = app.update('a', { config: { tag: 'a', value: 2 } })
+    const refresh = app.include().refresh()
+    await Promise.all([update, refresh])
+    await app.settle()
+
+    expect(app.config('a').value).toBe(2)
+    expect((await app.read())[0].config.value).toBe(2)
+  }, 10000)
+
+  it('does not write back when the file removes an entry', async () => {
+    const before = '# keep me\n' + yaml.dump([plugin('a', 1), plugin('b', 1)])
+    const app = await setup('tmp-sync-remove.yml', before)
+    expect(app.config('b')).toBeTruthy()
+
+    const after = '# keep me\n' + yaml.dump([plugin('a', 1)])
+    await writeFile(app.filename, after)
+    await app.settle()
+
+    expect(app.config('b')).toBeUndefined()
+    expect(await app.text()).toBe(after)
+    expect(app.logs('error')).toEqual([])
+  }, 10000)
+
+  it('does not write back when the file disables an entry', async () => {
+    const app = await setup('tmp-sync-disable.yml', '# keep me\n' + yaml.dump([plugin('a', 1)]))
+
+    const after = '# keep me\n' + yaml.dump([plugin('a', 1, { disabled: true })])
+    await writeFile(app.filename, after)
+    await app.settle()
+
+    expect(app.config('a')).toBeUndefined()
+    expect(await app.text()).toBe(after)
+  }, 10000)
+
+  it('merges a file edit and a runtime edit on different entries', async () => {
+    const app = await setup('tmp-sync-merge.yml', [plugin('a', 1), plugin('b', 1)])
+
+    // the file changes under us without any watcher telling us
+    await writeFile(app.filename, yaml.dump([plugin('a', 1), plugin('b', 2)]))
+    await app.update('a', { config: { tag: 'a', value: 2 } })
+    await app.settle()
+
+    expect(app.config('a').value).toBe(2)
+    expect(app.config('b').value).toBe(2)
+    const [a, b] = await app.read()
+    expect(a.config.value).toBe(2)
+    expect(b.config.value).toBe(2)
+    expect(app.logs('error')).toEqual([])
+  }, 10000)
+
+  // The webui saves entry A while the editor saves entry B and the watcher
+  // fires: whichever side gets to the include first, both edits survive.
+  for (const order of ['refresh first', 'update first'] as const) {
+    it(`merges a watcher-driven file edit racing a runtime edit (${order})`, async () => {
+      const app = await setup(`tmp-sync-race-${order.replace(' ', '-')}.yml`, [plugin('a', 1), plugin('b', 1)])
+
+      await writeFile(app.filename, yaml.dump([plugin('a', 1), plugin('b', 2)]))
+      const tasks: Promise<unknown>[] = []
+      if (order === 'refresh first') tasks.push(app.include().refresh())
+      tasks.push(app.update('a', { config: { tag: 'a', value: 2 } }))
+      if (order === 'update first') tasks.push(app.include().refresh())
+      await Promise.all(tasks)
+      await app.settle()
+
+      expect(app.config('a').value).toBe(2)
+      expect(app.config('b').value).toBe(2)
+      const [a, b] = await app.read()
+      expect(a.config.value).toBe(2)
+      expect(b.config.value).toBe(2)
+      expect(app.logs('error')).toEqual([])
+    }, 10000)
+  }
+
+  it('lets the file win a conflict on the same entry and reports it', async () => {
+    const app = await setup('tmp-sync-conflict.yml', [plugin('a', 1)])
+
+    await writeFile(app.filename, yaml.dump([plugin('a', 3)]))
+    await app.update('a', { config: { tag: 'a', value: 2 } })
+    await app.settle()
+
+    expect(app.config('a').value).toBe(3)
+    expect((await app.read())[0].config.value).toBe(3)
+    const errors = app.logs('error')
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatch(/conflict/)
+    expect(errors[0]).toMatch(/config/)
+  }, 10000)
+
+  it('combines a move in the file with an edit at runtime', async () => {
+    const app = await setup('tmp-sync-move.yml', [plugin('a', 1), group('g', [])])
+
+    await writeFile(app.filename, yaml.dump([group('g', [plugin('a', 1)])]))
+    await app.update('a', { config: { tag: 'a', value: 2 } })
+    await app.settle()
+
+    const include = app.include()
+    expect(include.store['a']!.parent).toBe(include.store['g']!.subgroup)
+    expect(app.config('a').value).toBe(2)
+    const [g] = await app.read()
+    expect(g.id).toBe('g')
+    expect(g.config).toEqual([plugin('a', 2)])
+    expect(app.logs('error')).toEqual([])
+  }, 10000)
+
+  it('never writes over a file it cannot parse', async () => {
+    const app = await setup('tmp-sync-broken.yml', [plugin('a', 1)])
+
+    await writeFile(app.filename, '- {\n')
+    await app.update('a', { config: { tag: 'a', value: 2 } })
+    await app.include().refresh()
+    expect(app.logs('warn').some(line => line.includes('failed to parse'))).toBe(true)
+    expect(await app.text()).toBe('- {\n')
+    expect(app.config('a').value).toBe(2)
+
+    // once the file is valid again the pending change goes out with the merge
+    await writeFile(app.filename, yaml.dump([plugin('a', 1), plugin('b', 1)]))
+    await app.settle()
+    const [a, b] = await app.read()
+    expect(a.config.value).toBe(2)
+    expect(b.config.value).toBe(1)
+    expect(app.config('b').value).toBe(1)
+  }, 10000)
+
+  it('routes changes to patch-owned keys into the parent config', async () => {
+    const inner = fixture('tmp-sync-inner-patch.yml')
+    files.push(inner)
+    const innerText = yaml.dump([plugin('a', 1)])
+    await writeFile(inner, innerText)
+    const app = await setup('tmp-sync-outer-patch.yml', [{
+      id: 'inc',
+      name: '@cordisjs/plugin-include',
+      config: {
+        path: './tmp-sync-inner-patch.yml',
+        patches: [{ id: 'a', disabled: true }],
+      },
+    }])
+    const innerInclude = () => app.include().store['inc']!.subtree as Include
+    await innerInclude().refresh()
+    expect(app.config('a')).toBeUndefined()
+
+    await app.update('inc:a', { disabled: false })
+    await innerInclude().refresh()
+    await app.settle()
+
+    expect(app.config('a').value).toBe(1)
+    expect(await readFile(inner, 'utf8')).toBe(innerText)
+    const [entry] = await app.read()
+    expect(entry.config.patches).toEqual([{ id: 'a', disabled: false }])
+    expect(app.logs('error')).toEqual([])
+  }, 10000)
+
+  it('routes changes to inserted entries into their patch', async () => {
+    const inner = fixture('tmp-sync-inner-insert.yml')
+    files.push(inner)
+    const innerText = yaml.dump([plugin('a', 1)])
+    await writeFile(inner, innerText)
+    const app = await setup('tmp-sync-outer-insert.yml', [{
+      id: 'inc',
+      name: '@cordisjs/plugin-include',
+      config: {
+        path: './tmp-sync-inner-insert.yml',
+        patches: [{ insert: [plugin('x', 1)] }],
+      },
+    }])
+    const innerInclude = () => app.include().store['inc']!.subtree as Include
+    await innerInclude().refresh()
+    await app.ctx.loader.await()
+    expect(app.config('x').value).toBe(1)
+
+    await app.update('inc:x', { config: { tag: 'x', value: 2 } })
+    await innerInclude().refresh()
+    await app.settle()
+
+    expect(app.config('x').value).toBe(2)
+    expect(await readFile(inner, 'utf8')).toBe(innerText)
+    const [entry] = await app.read()
+    expect(entry.config.patches).toEqual([{ insert: [plugin('x', 2)] }])
+  }, 10000)
+
+  it('keeps anonymous entries stable across reloads without writing', async () => {
+    const anonymous = { name: './config-plugin', config: { tag: 'anon', value: 1 } }
+    const text = yaml.dump([anonymous, plugin('b', 1)])
+    const app = await setup('tmp-sync-anonymous.yml', text)
+    expect(app.config('anon').value).toBe(1)
+    expect(await app.text()).toBe(text)
+    const applies = applied.filter(tag => tag === 'anon').length
+
+    const edited = yaml.dump([anonymous, plugin('b', 2)])
+    await writeFile(app.filename, edited)
+    await app.settle()
+
+    expect(app.config('b').value).toBe(2)
+    expect(applied.filter(tag => tag === 'anon')).toHaveLength(applies)
+    expect(await app.text()).toBe(edited)
+
+    // the assigned id travels with the next write
+    await app.update('b', { config: { tag: 'b', value: 3 } })
+    await app.settle()
+    const [first] = await app.read()
+    expect(first.id).toMatch(/^[0-9a-f]{8}$/)
+    expect(first.config.tag).toBe('anon')
+  }, 10000)
+
+  it('keeps runtime changes in memory when the file is read-only', async () => {
+    const app = await setup('tmp-sync-readonly.yml', [plugin('a', 1), plugin('b', 1)])
+    const text = await app.text()
+    await chmod(app.filename, 0o444)
+
+    await app.update('a', { config: { tag: 'a', value: 2 } })
+    await app.settle()
+
+    expect(app.config('a').value).toBe(2)
+    expect(await app.text()).toBe(text)
+    expect(app.logs('warn').some(line => line.includes('read-only'))).toBe(true)
+
+    // an unrelated file edit keeps the in-memory overlay
+    await chmod(app.filename, 0o644)
+    await writeFile(app.filename, yaml.dump([plugin('a', 1), plugin('b', 2)]))
+    await chmod(app.filename, 0o444)
+    await app.settle()
+
+    expect(app.config('a').value).toBe(2)
+    expect(app.config('b').value).toBe(2)
+    expect((await app.read())[0].config.value).toBe(1)
+  }, 10000)
+
+  it('removes a nested entry through its composite id', async () => {
+    const app = await setup('tmp-sync-nested-remove.yml', [plugin('a', 1), plugin('b', 1)])
+
+    // the public id is `<include>:<local>`; the group's store is keyed by the local id
+    app.ctx.loader.remove(`${app.id}:a`)
+    await app.settle()
+
+    expect(app.config('a')).toBeUndefined()
+    expect(app.config('b').value).toBe(1)
+    expect(app.include().store['a']).toBeUndefined()
+    expect((await app.read()).map(entry => entry.id)).toEqual(['b'])
+  }, 10000)
+
+  it('flushes pending changes on dispose', async () => {
+    const app = await setup('tmp-sync-dispose.yml', [plugin('a', 1)])
+
+    const task = app.update('a', { config: { tag: 'a', value: 2 } })
+    await fiber!.dispose()
+    await task.catch(() => {})
+
+    expect((await app.read())[0].config.value).toBe(2)
+  }, 10000)
+})

--- a/packages/include/tests/sync.spec.ts
+++ b/packages/include/tests/sync.spec.ts
@@ -1,79 +1,12 @@
-import { Context, Fiber, Message } from 'cordis'
-import Loader from '@cordisjs/plugin-loader'
-import { expect, describe, it, afterEach } from 'vitest'
-import { chmod, readFile, rm, writeFile } from 'node:fs/promises'
-import { fileURLToPath } from 'node:url'
+import { expect, describe, it } from 'vitest'
+import { readFile, chmod, writeFile } from 'node:fs/promises'
 import * as yaml from 'js-yaml'
 import Include from '../src'
 import { applied } from './fixtures/config-plugin'
-
-const fixture = (name: string) => fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url))
-
-const plugin = (id: string, value: number, extra: any = {}) => ({
-  id,
-  name: './config-plugin',
-  config: { tag: id, value },
-  ...extra,
-})
-
-const group = (id: string, config: any[]) => ({
-  id,
-  name: '@cordisjs/plugin-group',
-  group: true,
-  config,
-})
+import { fixture, group, harness, plugin } from './utils'
 
 describe('Include sync', () => {
-  let ctx: Context | undefined
-  let fiber: Fiber<Context> | undefined
-  const files: string[] = []
-
-  afterEach(async () => {
-    await fiber?.dispose()
-    ctx = fiber = undefined
-    for (const file of files.splice(0)) {
-      await chmod(file, 0o644).catch(() => {})
-      await rm(file, { force: true })
-    }
-  })
-
-  async function setup(name: string, data: any[] | string, config: any = {}) {
-    const filename = fixture(name)
-    files.push(filename)
-    await writeFile(filename, typeof data === 'string' ? data : yaml.dump(data))
-
-    ctx = new Context()
-    const messages: Message[] = []
-    ctx.logger.exporter({ export: message => messages.push(message) })
-    fiber = await ctx.plugin(Loader, { baseUrl: import.meta.url })
-    const id = await ctx.loader.create({
-      name: '@cordisjs/plugin-include',
-      config: { path: `./fixtures/${name}`, ...config },
-    })
-    await ctx.loader.store[id]!.fiber!.await()
-
-    const include = () => ctx!.loader.store[id]!.subtree as Include
-    // what hmr does on a change event; `refresh` also waits for any write
-    const settle = async () => {
-      await include().refresh()
-      await ctx!.loader.await()
-    }
-    await settle()
-
-    return {
-      ctx: ctx!,
-      id,
-      filename,
-      include,
-      settle,
-      messages,
-      text: () => readFile(filename, 'utf8'),
-      read: async () => yaml.load(await readFile(filename, 'utf8')) as any[],
-      config: (tag: string) => ctx!.bail('test/config', tag),
-      logs: (type: Message['type']) => messages.filter(m => m.type === type).map(m => m.args.join(' ')),
-      update: (local: string, options: any) => ctx!.loader.update(`${id}:${local}`, options),
-    }
-  }
+  const { setup } = harness()
 
   it('coalesces consecutive writes into the latest state', async () => {
     const app = await setup('tmp-sync-coalesce.yml', [plugin('a', 1)])
@@ -216,7 +149,6 @@ describe('Include sync', () => {
 
   it('routes changes to patch-owned keys into the parent config', async () => {
     const inner = fixture('tmp-sync-inner-patch.yml')
-    files.push(inner)
     const innerText = yaml.dump([plugin('a', 1)])
     await writeFile(inner, innerText)
     const app = await setup('tmp-sync-outer-patch.yml', [{
@@ -227,6 +159,7 @@ describe('Include sync', () => {
         patches: [{ id: 'a', disabled: true }],
       },
     }])
+    app.files.push(inner)
     const innerInclude = () => app.include().store['inc']!.subtree as Include
     await innerInclude().refresh()
     expect(app.config('a')).toBeUndefined()
@@ -244,7 +177,6 @@ describe('Include sync', () => {
 
   it('routes changes to inserted entries into their patch', async () => {
     const inner = fixture('tmp-sync-inner-insert.yml')
-    files.push(inner)
     const innerText = yaml.dump([plugin('a', 1)])
     await writeFile(inner, innerText)
     const app = await setup('tmp-sync-outer-insert.yml', [{
@@ -255,6 +187,7 @@ describe('Include sync', () => {
         patches: [{ insert: [plugin('x', 1)] }],
       },
     }])
+    app.files.push(inner)
     const innerInclude = () => app.include().store['inc']!.subtree as Include
     await innerInclude().refresh()
     await app.ctx.loader.await()
@@ -330,11 +263,27 @@ describe('Include sync', () => {
     expect((await app.read()).map(entry => entry.id)).toEqual(['b'])
   }, 10000)
 
+  it('retries a write that failed earlier when disposing', async () => {
+    const app = await setup('tmp-sync-dispose-retry.yml', [plugin('a', 1)])
+    const text = await app.text()
+    await chmod(app.filename, 0o444)
+
+    await app.update('a', { config: { tag: 'a', value: 2 } })
+    await app.settle()
+    expect(await app.text()).toBe(text)
+
+    // the file becomes writable again, but nothing else touches the tree
+    await chmod(app.filename, 0o644)
+    await app.dispose()
+
+    expect((await app.read())[0].config.value).toBe(2)
+  }, 10000)
+
   it('flushes pending changes on dispose', async () => {
     const app = await setup('tmp-sync-dispose.yml', [plugin('a', 1)])
 
     const task = app.update('a', { config: { tag: 'a', value: 2 } })
-    await fiber!.dispose()
+    await app.dispose()
     await task.catch(() => {})
 
     expect((await app.read())[0].config.value).toBe(2)

--- a/packages/include/tests/utils.ts
+++ b/packages/include/tests/utils.ts
@@ -1,0 +1,83 @@
+import { Context, Fiber, Message } from 'cordis'
+import Loader from '@cordisjs/plugin-loader'
+import { afterEach } from 'vitest'
+import { chmod, readFile, rm, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import * as yaml from 'js-yaml'
+import Include from '../src'
+
+export const fixture = (name: string) => fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url))
+
+export const plugin = (id: string, value: number, extra: any = {}) => ({
+  id,
+  name: './config-plugin',
+  config: { tag: id, value },
+  ...extra,
+})
+
+export const group = (id: string, config: any[]) => ({
+  id,
+  name: '@cordisjs/plugin-group',
+  group: true,
+  config,
+})
+
+/**
+ * Per-suite harness: `setup` boots a loader with one include over a fresh
+ * fixture file; everything it created is disposed and removed after each test.
+ */
+export function harness() {
+  let fiber: Fiber<Context> | undefined
+  const files: string[] = []
+
+  afterEach(async () => {
+    await fiber?.dispose()
+    fiber = undefined
+    for (const file of files.splice(0)) {
+      await chmod(file, 0o644).catch(() => {})
+      await rm(file, { force: true })
+    }
+  })
+
+  async function setup(name: string, data: any[] | string, config: any = {}) {
+    const filename = fixture(name)
+    files.push(filename)
+    await writeFile(filename, typeof data === 'string' ? data : yaml.dump(data))
+
+    const ctx = new Context()
+    const messages: Message[] = []
+    ctx.logger.exporter({ export: message => messages.push(message) })
+    fiber = await ctx.plugin(Loader, { baseUrl: import.meta.url })
+    const id = await ctx.loader.create({
+      name: '@cordisjs/plugin-include',
+      config: { path: `./fixtures/${name}`, ...config },
+    })
+    await ctx.loader.store[id]!.fiber!.await()
+
+    const include = () => ctx.loader.store[id]!.subtree as Include
+    // what hmr does on a change event; `refresh` also waits for any write
+    const settle = async () => {
+      await include().refresh()
+      await ctx.loader.await()
+    }
+    await settle()
+
+    return {
+      ctx,
+      id,
+      filename,
+      include,
+      settle,
+      messages,
+      files,
+      dispose: () => fiber!.dispose(),
+      text: () => readFile(filename, 'utf8'),
+      read: async () => yaml.load(await readFile(filename, 'utf8')) as any[],
+      config: (tag: string) => ctx.bail('test/config', tag),
+      logs: (type: Message['type']) => messages.filter(m => m.type === type).map(m => m.args.join(' ')),
+      update: (local: string, options: any) => ctx.loader.update(`${id}:${local}`, options),
+    }
+  }
+
+  return { setup }
+}

--- a/packages/include/tests/write.spec.ts
+++ b/packages/include/tests/write.spec.ts
@@ -1,0 +1,121 @@
+import { expect, describe, it, beforeAll, afterAll, afterEach } from 'vitest'
+import { writeFile } from 'node:fs/promises'
+import { createRequire, syncBuiltinESMExports } from 'node:module'
+import * as yaml from 'js-yaml'
+import { harness, plugin } from './utils'
+
+/**
+ * Failure injection for `rename`. Every scheduled failure rejects with the
+ * given code; `beforeFail` runs right before the rejection so a test can
+ * simulate an external writer racing the include.
+ */
+const renames = {
+  calls: 0,
+  failures: 0,
+  code: 'EBUSY',
+  beforeFail: undefined as (() => Promise<void>) | undefined,
+}
+
+// The loader imports the include through Node's own module loader (the tests
+// run with --expose-internals), outside vitest's module graph. Patching the
+// CJS side of the builtin and syncing the ESM bindings reaches every copy.
+const fsp = createRequire(import.meta.url)('node:fs/promises') as typeof import('node:fs/promises')
+const actualRename = fsp.rename
+
+describe('Include write', () => {
+  const { setup } = harness()
+
+  beforeAll(() => {
+    fsp.rename = async (from, to) => {
+      renames.calls++
+      if (renames.failures > 0) {
+        renames.failures--
+        await renames.beforeFail?.()
+        throw Object.assign(new Error(`${renames.code}: resource busy`), { code: renames.code })
+      }
+      return actualRename(from, to)
+    }
+    syncBuiltinESMExports()
+  })
+
+  afterAll(() => {
+    fsp.rename = actualRename
+    syncBuiltinESMExports()
+  })
+
+  afterEach(() => {
+    Object.assign(renames, { calls: 0, failures: 0, code: 'EBUSY', beforeFail: undefined })
+  })
+
+  it('retries a rename that fails transiently', async () => {
+    const app = await setup('tmp-write-retry.yml', [plugin('a', 1)])
+    renames.calls = 0
+    renames.failures = 2
+
+    await app.update('a', { config: { tag: 'a', value: 2 } })
+    await app.settle()
+
+    expect(renames.calls).toBe(3)
+    expect((await app.read())[0].config.value).toBe(2)
+    expect(app.logs('warn')).toEqual([])
+    expect(app.logs('error')).toEqual([])
+  }, 10000)
+
+  it('never overwrites a change that lands while it waits to retry', async () => {
+    const app = await setup('tmp-write-race.yml', [plugin('a', 1), plugin('b', 1)])
+    renames.calls = 0
+    renames.failures = 1
+    renames.beforeFail = () => writeFile(app.filename, yaml.dump([plugin('a', 1), plugin('b', 2)]))
+
+    await app.update('a', { config: { tag: 'a', value: 2 } })
+    await app.settle()
+
+    // the stale check before the retry sees the external edit, and the
+    // runtime change is merged into it
+    const [a, b] = await app.read()
+    expect(a.config.value).toBe(2)
+    expect(b.config.value).toBe(2)
+    expect(app.config('b').value).toBe(2)
+    expect(renames.calls).toBe(2)
+    expect(app.logs('error')).toEqual([])
+  }, 10000)
+
+  it('does not retry other errors, but still flushes on dispose', async () => {
+    const app = await setup('tmp-write-fatal.yml', [plugin('a', 1)])
+    const text = await app.text()
+    renames.calls = 0
+    renames.failures = 1
+    renames.code = 'ENOSPC'
+
+    await app.update('a', { config: { tag: 'a', value: 2 } })
+    await app.settle()
+
+    expect(renames.calls).toBe(1)
+    expect(await app.text()).toBe(text)
+    expect(app.logs('warn').some(line => line.includes('failed to write'))).toBe(true)
+    expect(app.config('a').value).toBe(2)
+
+    await app.dispose()
+    expect((await app.read())[0].config.value).toBe(2)
+  }, 10000)
+
+  it('gives up after a bounded number of attempts and keeps the change', async () => {
+    const app = await setup('tmp-write-bounded.yml', [plugin('a', 1)])
+    const text = await app.text()
+    renames.calls = 0
+    renames.failures = Infinity
+
+    await app.update('a', { config: { tag: 'a', value: 2 } })
+    await app.settle()
+
+    expect(renames.calls).toBe(11)
+    expect(await app.text()).toBe(text)
+    expect(app.logs('warn').some(line => line.includes('failed to write'))).toBe(true)
+    expect(app.config('a').value).toBe(2)
+
+    // the lock clears; the journal goes out with the dispose flush
+    renames.failures = 0
+    await app.dispose()
+    expect((await app.read())[0].config.value).toBe(2)
+  }, 10000)
+})

--- a/packages/loader/src/config/group.ts
+++ b/packages/loader/src/config/group.ts
@@ -35,12 +35,17 @@ export class EntryGroup {
 
   remove(id: string, isDispose = false) {
     const entry = this.tree.store[id]
-    if (!entry) return
+    // An entry that another group already adopted (a file-driven move) is not
+    // ours to dispose anymore.
+    if (!entry || entry.parent !== this) return
+    // Unregister before disposing: the loader's `internal/plugin` handler
+    // distinguishes "removed by the loader" from "disposed itself" by checking
+    // whether the entry is still in the store.
+    delete this.tree.store[id]
     entry.fiber?.dispose()
     if (!isDispose) {
       this.unlink(entry.options)
     }
-    delete this.tree.store[id]
     this.context.emit('loader/partial-dispose', entry, entry.options, false)
   }
 

--- a/packages/loader/src/config/group.ts
+++ b/packages/loader/src/config/group.ts
@@ -35,8 +35,8 @@ export class EntryGroup {
 
   remove(id: string, isDispose = false) {
     const entry = this.tree.store[id]
-    // An entry that another group already adopted (a file-driven move) is not
-    // ours to dispose anymore.
+    // an entry that another group already adopted (a file-driven move) belongs
+    // to that group now
     if (!entry || entry.parent !== this) return
     // Unregister before disposing: the loader's `internal/plugin` handler
     // distinguishes "removed by the loader" from "disposed itself" by checking

--- a/packages/loader/src/config/tree.ts
+++ b/packages/loader/src/config/tree.ts
@@ -3,6 +3,23 @@ import { Dict, isNonNullable } from 'cosmokit'
 import { Entry, EntryOptions } from './entry.ts'
 import { EntryGroup } from './group.ts'
 
+/**
+ * One tree-side mutation, reported to `EntryTree.commit()` synchronously after
+ * it has been applied to `entry.options` / `group.data`.
+ *
+ * - `options` absent: the entry was removed from `group`.
+ * - `legacy` absent: the entry was created in `group`.
+ * - both present: the entry was updated and now lives in `group`; `from` is
+ *   the group it left if the update moved it.
+ */
+export interface EntryChange {
+  id: string
+  group: EntryGroup
+  from?: EntryGroup
+  options?: EntryOptions
+  legacy?: EntryOptions
+}
+
 export abstract class EntryTree {
   static readonly sep = ':'
 
@@ -75,29 +92,39 @@ export abstract class EntryTree {
 
   async create(options: Omit<EntryOptions, 'id'>, parent: string | null = null, position = Infinity) {
     const group = this.resolveGroup(parent)
+    const id = group.tree.ensureId(options)
     group.data.splice(position, 0, options as EntryOptions)
-    group.tree.write()
+    group.tree.commit({ id, group, options: options as EntryOptions })
     return group.create(options)
   }
 
   remove(id: string) {
     const entry = this.resolve(id)
-    entry.parent.remove(id)
-    entry.parent.tree.write()
+    const group = entry.parent
+    const legacy = entry.options
+    group.remove(legacy.id)
+    group.tree.commit({ id: legacy.id, group, legacy })
   }
 
   async update(id: string, options: Omit<EntryOptions, 'id' | 'name'>, parent?: string | null, position?: number) {
     const entry = this.resolve(id)
     const source = entry.parent
+    const legacy = { ...entry.options }
     if (parent !== undefined) {
       const target = this.resolveGroup(parent)
       source.unlink(entry.options)
       target.data.splice(position ?? Infinity, 0, entry.options)
-      target.tree.write()
       entry.parent = target
     }
-    source.tree.write()
-    return entry.update(options, false, true)
+    // `Entry.update` assigns the new options before its first `await`, so the
+    // change is fully visible to `commit()` once the call returns.
+    const task = entry.update(options, false, true)
+    if (entry.parent.tree !== source.tree) {
+      source.tree.commit({ id: legacy.id, group: source, legacy })
+    }
+    const from = entry.parent === source ? undefined : source
+    entry.parent.tree.commit({ id: legacy.id, group: entry.parent, from, options: entry.options, legacy })
+    return task
   }
 
   import(name: string, getOuterStack?: () => string[]) {
@@ -119,5 +146,5 @@ export abstract class EntryTree {
     }, getOuterStack)
   }
 
-  abstract write(): void
+  abstract commit(change: EntryChange): void
 }

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -74,8 +74,10 @@ export class Loader extends EntryTree {
     ctx.on('internal/update', function (config, noSave, next) {
       if (!this.entry || noSave || this.parent.fiber?.entry === this.entry) return next()
       const unparse = this.runtime?.Config?.['simplify']
-      this.entry.options.config = unparse ? unparse(config) : config
-      this.entry.parent.tree.write()
+      const { entry } = this
+      const legacy = { ...entry.options }
+      entry.options.config = unparse ? unparse(config) : config
+      entry.parent.tree.commit({ id: entry.options.id, group: entry.parent, options: entry.options, legacy })
       return next()
     }, { global: true, prepend: true })
 
@@ -113,21 +115,27 @@ export class Loader extends EntryTree {
       // case 5: the entry's tree is being disposed
       if (!fiber.entry.parent.tree.ctx.fiber.uid) return
 
-      this.showLog(fiber.entry, 'unload')
+      const { entry } = fiber
+      this.showLog(entry, 'unload')
 
-      // case 6: fiber is disposed by loader behavior
+      // case 6: the entry is being removed by the loader (`EntryGroup.remove`
+      // unregisters it before disposing the fiber)
+      if (entry.parent.tree.store[entry.options.id] !== entry) return
+
+      // case 7: fiber is disposed by loader behavior
       // such as inject checker, config file update, ancestor group disable
-      if (fiber.entry.disabled) return
+      if (entry.disabled) return
 
-      fiber.entry.options.disabled = true
-      fiber.entry.parent.tree.write()
+      const legacy = { ...entry.options }
+      entry.options.disabled = true
+      entry.parent.tree.commit({ id: entry.options.id, group: entry.parent, options: entry.options, legacy })
     })
 
     ctx.plugin(isolate)
   }
 
-  write() {
-    // Loader's root tree is in-memory; writes are no-ops.
+  commit() {
+    // the root tree lives in memory only; there is nothing to persist to
   }
 
   [Service.check]() {

--- a/packages/loader/tests/commit.spec.ts
+++ b/packages/loader/tests/commit.spec.ts
@@ -1,0 +1,156 @@
+import { Mock, mock } from 'node:test'
+import { expect, describe, it, beforeAll, beforeEach } from 'vitest'
+import { Context } from 'cordis'
+import MockLoader, { sleep } from './utils'
+
+describe('EntryTree.commit: change reports', () => {
+  const root = new Context()
+
+  let loader!: MockLoader
+  let foo!: Mock<Function>
+
+  beforeAll(async () => {
+    await root.plugin(MockLoader)
+    loader = root.loader as any
+    foo = loader.mock('foo', () => {})
+  })
+
+  beforeEach(() => {
+    loader.changes = []
+  })
+
+  let id!: string
+  let group!: string
+
+  it('create reports a created entry with its id assigned', async () => {
+    id = await loader.create({ name: 'foo', config: { a: 1 } })
+    group = await loader.create({
+      name: '@cordisjs/plugin-group',
+      group: true,
+      config: [],
+    })
+
+    expect(loader.changes).to.have.length(2)
+    const [change] = loader.changes
+    expect(change.id).to.equal(id)
+    expect(change.group).to.equal(loader.root)
+    expect(change.legacy).to.be.undefined
+    expect(change.options).to.deep.equal({ id, name: 'foo', config: { a: 1 } })
+    expect(loader.root.data).to.include(change.options)
+  })
+
+  it('update reports the new options together with the previous ones', async () => {
+    await loader.update(id, { config: { a: 2 } })
+
+    expect(loader.changes).to.have.length(1)
+    const [change] = loader.changes
+    expect(change.id).to.equal(id)
+    expect(change.legacy).to.deep.equal({ id, name: 'foo', config: { a: 1 } })
+    expect(change.options).to.deep.equal({ id, name: 'foo', config: { a: 2 } })
+    // reported after the mutation, not before
+    expect(change.options).to.equal(loader.store[id]!.options)
+  })
+
+  it('move reports the target group', async () => {
+    await loader.update(id, {}, group)
+
+    expect(loader.changes).to.have.length(1)
+    const [change] = loader.changes
+    expect(change.group).to.equal(loader.store[group]!.subgroup)
+    expect(change.from).to.equal(loader.root)
+    expect(change.options).to.deep.equal(change.legacy)
+  })
+
+  it('update in place does not report a move', async () => {
+    await loader.update(id, { config: { a: 4 } })
+
+    expect(loader.changes).to.have.length(1)
+    expect(loader.changes[0].from).to.be.undefined
+  })
+
+  it('fiber.update from inside the plugin reports a config change', async () => {
+    const fiber = loader.expectFiber(id)
+    await fiber.update({ a: 5 })
+
+    expect(loader.changes).to.have.length(1)
+    const [change] = loader.changes
+    expect(change.legacy!.config).to.deep.equal({ a: 4 })
+    expect(change.options!.config).to.deep.equal({ a: 5 })
+  })
+
+  it('remove reports the removed entry', async () => {
+    await loader.remove(id)
+
+    expect(loader.changes).to.have.length(1)
+    const [change] = loader.changes
+    expect(change.id).to.equal(id)
+    expect(change.options).to.be.undefined
+    expect(change.legacy!.name).to.equal('foo')
+    expect(loader.store[id]).to.be.undefined
+  })
+
+  it('does not mistake a child fiber disposing itself for the entry (#19)', async () => {
+    loader.mock('parent', (ctx: Context) => {
+      const child = ctx.plugin(() => {})
+      child.dispose()
+    })
+    const parent = await loader.create({ name: 'parent' })
+    await sleep()
+
+    loader.expectFiber(parent)
+    expect(loader.store[parent]!.options.disabled).to.be.undefined
+    expect(loader.changes.filter(change => change.options?.disabled)).to.have.length(0)
+    await loader.remove(parent)
+  })
+
+  it('does not report anything for reads', async () => {
+    expect(foo.mock.calls.length).to.be.greaterThan(0)
+    await loader.read([
+      { id: 'x', name: 'foo' },
+      { id: group, name: '@cordisjs/plugin-group', group: true, config: [] },
+    ])
+    loader.changes = []
+
+    // a removal driven by the config file must not be mistaken for a
+    // self-dispose and written back as `disabled: true`
+    await loader.read([
+      { id: group, name: '@cordisjs/plugin-group', group: true, config: [] },
+    ])
+    await sleep()
+    expect(loader.changes).to.have.length(0)
+    expect(loader.store['x']).to.be.undefined
+  })
+})
+
+describe('EntryGroup.remove: file-driven moves', () => {
+  const root = new Context()
+  const dispose = mock.fn()
+
+  let loader!: MockLoader
+  let foo!: Mock<Function>
+
+  beforeAll(async () => {
+    await root.plugin(MockLoader)
+    loader = root.loader as any
+    foo = loader.mock('foo', () => dispose)
+  })
+
+  it('keeps an entry that another group adopted', async () => {
+    await loader.read([
+      { id: 'x', name: 'foo' },
+      { id: 'g', name: '@cordisjs/plugin-group', group: true, config: [] },
+    ])
+    expect(foo.mock.calls).to.have.length(1)
+
+    await loader.read([
+      { id: 'g', name: '@cordisjs/plugin-group', group: true, config: [{ id: 'x', name: 'foo' }] },
+    ])
+    await sleep()
+
+    // whichever of remove / adopt ran first, the entry survives in the store
+    expect(loader.store['x']).to.be.ok
+    expect(loader.store['x']!.parent).to.equal(loader.store['g']!.subgroup)
+    loader.expectFiber('x')
+    loader.expectEnable(foo)
+  })
+})

--- a/packages/loader/tests/commit.spec.ts
+++ b/packages/loader/tests/commit.spec.ts
@@ -47,7 +47,7 @@ describe('EntryTree.commit: change reports', () => {
     expect(change.id).to.equal(id)
     expect(change.legacy).to.deep.equal({ id, name: 'foo', config: { a: 1 } })
     expect(change.options).to.deep.equal({ id, name: 'foo', config: { a: 2 } })
-    // reported after the mutation, not before
+    // reported after the mutation
     expect(change.options).to.equal(loader.store[id]!.options)
   })
 
@@ -111,8 +111,7 @@ describe('EntryTree.commit: change reports', () => {
     ])
     loader.changes = []
 
-    // a removal driven by the config file must not be mistaken for a
-    // self-dispose and written back as `disabled: true`
+    // a removal driven by the config file is a read, so nothing is reported
     await loader.read([
       { id: group, name: '@cordisjs/plugin-group', group: true, config: [] },
     ])

--- a/packages/loader/tests/utils.ts
+++ b/packages/loader/tests/utils.ts
@@ -1,6 +1,6 @@
 import { Dict } from 'cosmokit'
 import { Context, Fiber, Plugin } from 'cordis'
-import { EntryOptions, Group, Loader } from '../src'
+import { EntryChange, EntryOptions, Group, Loader } from '../src'
 import { Mock, mock } from 'node:test'
 import { expect } from 'vitest'
 
@@ -15,6 +15,7 @@ declare module '../src' {
 
 export default class MockLoader extends Loader {
   public data: EntryOptions[] = []
+  public changes: EntryChange[] = []
   public modules: Dict<Plugin.Object> = Object.create(null)
 
   constructor(ctx: Context) {
@@ -27,8 +28,9 @@ export default class MockLoader extends Loader {
     })
   }
 
-  write() {
+  commit(change: EntryChange) {
     this.data = this.root.data
+    this.changes.push(change)
   }
 
   async read(data: any) {


### PR DESCRIPTION
Fixes #112. Fixes #114.

Supersedes #47, #57, #74, #115, #116.

## Background

`@cordisjs/plugin-include` sits between a config file and an entry tree and has to serve two kinds of operations that can interleave arbitrarily, both asynchronous:

- **reads**, triggered by hmr when the file changes: parse the file and update the tree;
- **writes**, triggered by the loader or a fiber (webui edits, `fiber.update` saving config, a plugin disposing itself): persist the current tree to the file.

For this to be dependable, the plugin needs three properties:

1. **Confluence.** Consecutive reads end in the state of the last read; consecutive writes end with the file holding the last update. No races between the two.
2. **No feedback loops.** A read must never cause a write (otherwise an editor save reformats the user's file); a write must never be mistaken for an external change by the watcher. Writes also cannot go straight to the file — a reader could see a truncated file — so they go through a temp file and `rename`, which the watcher has to survive.
3. **Conflicts at entry granularity.** Editing entry A in the webui while entry B is edited in the file should keep both. When the same entry is edited on both sides, the outcome must be deterministic and reported.

The previous implementation had none of these. Among the concrete failures: two overlapping writes shared one `.tmp` and the second `rename` crashed with ENOENT; the cache was updated before the `rename` landed, so a read in that window applied stale data and the file and tree never converged again; deleting an entry in the file made the loader treat the resulting dispose as a self-dispose and write `disabled: true` back, reformatting the file; every read replaced the tree wholesale, dropping unflushed runtime edits on unrelated entries; and any write baked the include's `patches` into the target file.

## Model

The include keeps three states apart — the **file**, a **cache** of the last file state it read or wrote, and the **live tree** — plus a **journal** of tree-side edits that have not reached the file yet. The cache doubles as the merge base.

- **The loader reports every tree-side change.** `EntryTree.write()` now receives an `EntryChange` (`id`, `group`, `from`, `options`, `legacy`), reported synchronously after the mutation. The include turns it into a per-key delta relative to `legacy`. Deltas are never derived by diffing the live tree against the file: the tree is reconciled asynchronously and a not-yet-created nested entry would read as a deletion.
- **Reads are three-way merges.** A read parses the file, reconciles the journal against the previous cache and the new file (the file wins conflicts, each one logged as an error), commits the cache, and schedules the tree to become `applyPatches(cache) ⊕ journal`.
- **Writes route the journal to its owner.** Each `(entry, key)` is owned by the file, by a patch that overrides that key, or by the patch that inserted the entry; changes go to the target file or back into the include's own `patches` accordingly. A write first checks that the file still matches the cache (otherwise it reads first), writes a dot-prefixed temp file, and re-checks right before the `rename`. The only retry is at the primitive level: on Windows a `rename` rejected with `EACCES` / `EPERM` / `EBUSY` (typically a scanner holding the freshly written file) is retried a bounded number of times, with the stale check repeated before every attempt so a change that lands while waiting is merged rather than overwritten. Any other failure keeps the journal and logs a warning; `stop()` re-drives a pending journal once more before the tree goes away, since nothing else would trigger it.
- **Two loops, deliberately decoupled.** A drain loop does the structural work (read, merge, write) and never waits for fibers; an apply loop runs `root.update()` serially and only ever applies the latest intended tree. A slow or hung plugin can delay the tree, but not config I/O.
- **File-driven removals no longer write.** `EntryGroup.remove` unregisters the entry before disposing its fiber, and the loader's `internal/plugin` handler treats "not in the store" as a removal rather than a self-dispose.

`refresh()` never rejects anymore — an unreadable or unparsable file is logged by the include and leaves the tree as it was — so hmr needs no error handling of its own and is unchanged.

## Tests

- `loader/tests/write.spec.ts`: `write()` receives the right change for create / update / move / remove; reads report nothing; a file-driven move keeps the entry.
- `include/tests/sync.spec.ts`: write coalescing, a refresh inside a write, no write-back on file-driven remove / disable, merges across entries (with and without a racing watcher event), same-entry conflict with the file winning, move-vs-edit, refusing to write over an unparsable file, routing to patch-owned keys and inserted entries, anonymous entries, read-only files, flush on dispose, a write that failed earlier getting retried on dispose.
- `include/tests/write.spec.ts`: the Windows rename retry — transient `EBUSY` resolves within the bound, an external edit landing during the wait is merged instead of clobbered, the same codes are not retried off Windows, and a persistent failure gives up after the bound with the journal intact. `rename` is injected through `module.syncBuiltinESMExports()` because the loader imports the include via Node's own loader (`--expose-internals`), out of `vi.mock`'s reach.
- `hmr/tests`: the watcher survives the include's rename-based writes without a feedback loop; an unparsable config only warns.
- Existing `reload.spec` / `patch.spec` keep their contracts; teardown now awaits `dispose()` instead of sleeping.