### PR TITLE
ci: setup test on Windows and macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,12 +54,16 @@ jobs:
           yarn yakumo publish
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         node-version: [24, 26]
+        exclude:
+          - os: windows-latest
+            node-version: 26
 
     steps:
       - name: Check out

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 26
+      - name: Install Corepack
+        run: npm install -g --force corepack@latest
       - name: Enable Corepack
         run: corepack enable
       - name: Install
@@ -35,7 +37,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 26
+      - name: Install Corepack
+        run: npm install -g --force corepack@latest
       - name: Enable Corepack
         run: corepack enable
       - name: Install
@@ -59,11 +63,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [24, 26]
-        exclude:
-          - os: windows-latest
-            node-version: 26
 
     steps:
       - name: Check out
@@ -72,6 +73,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install Corepack
+        run: npm install -g --force corepack@latest
       - name: Enable Corepack
         run: corepack enable
       - name: Install


### PR DESCRIPTION
CI runs the test suite only on ubuntu-latest, but cordis is also used by
Windows developers and Windows-specific regressions have reached main before
(see #58). This adds windows-latest to the test job matrix.

Windows runs Node 24: the windows-latest + Node 26 cell is excluded because
Corepack was removed from the Node.js distribution starting with Node 25, so
the repository's existing `corepack enable`-based install steps fall back to
the runner's preinstalled Yarn 1.x there ("packageManager": "yarn@4.14.1" vs
global Yarn 1.22.22). The exclusion can be lifted once setup-node restores
Corepack on Windows for Node 25+.

Verified locally on Windows with Yarn 4.14.1, using the same commands as the
CI test job, on three Node versions:

  corepack yarn install --no-immutable
  corepack yarn test:json   # Test Files 20 passed (20), Tests 201 passed (201)

Node 22, 24, and 26 all pass (201/201 each, exit 0).

No source changes; this PR itself exercises the new Windows matrix cells.
