### PR TITLE
fix(publish): include src in tarballs of core, loader and timer

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,8 @@
   },
   "files": [
     "lib",
-    "bin.js"
+    "bin.js",
+    "src"
   ],
   "repository": {
     "type": "git",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -14,7 +14,8 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "author": "Shigma <shigma10826@gmail.com>",
   "license": "MIT",

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -14,7 +14,8 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "author": "Shigma <shigma10826@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Problem

Three packages declare a `./src/*` export subpath:

- `cordis` (`packages/core/package.json`)
- `@cordisjs/plugin-loader` (`packages/loader/package.json`)
- `@cordisjs/plugin-timer` (`packages/timer/package.json`)

but their `files` arrays do not include `src`. The published tarballs therefore carry an export map entry that points at files absent from the package, so an import the map advertises (e.g. `cordis/src/context.ts`) fails with `ERR_MODULE_NOT_FOUND` against an installed package.

## Evidence

`npm pack --dry-run` on `main` ships only 3 / 2 / 1 entries for core / loader / timer. After adding `src` to `files`, the same command ships 22 / 19 / 4 entries and the `src/` tree is present in the tarball.

None of the other workspace packages declare a `./src/*` export.

## Change

- `packages/core/package.json`: add `src` to `files`
- `packages/loader/package.json`: add `src` to `files`
- `packages/timer/package.json`: add `src` to `files`

No other manifest fields are touched.
