### PR TITLE
fix(include): persist runtime edits in effective patch owners

### DIFF
--- a/packages/include/src/patch.ts
+++ b/packages/include/src/patch.ts
@@ -156,6 +156,8 @@ export class PatchIndex {
         return
       }
       if (!id) return
+      const inserted = this.inserts.get(id)
+      if (patch.name && inserted && patch.name !== inserted.options.name) return
       const keys = this.keys.get(id) ?? new Map<string, number>()
       for (const key of Object.keys(omit(patch, ['id', 'insert', 'name']))) {
         keys.set(key, index)
@@ -173,9 +175,9 @@ export class PatchIndex {
   /** Owner of one key of an entry. */
   key(id: string, key: string): EntryOwner {
     const insert = this.inserts.get(id)
-    if (insert) return insert
     const index = this.keys.get(id)?.get(key)
-    return index === undefined ? { type: 'file' } : { type: 'patch', index }
+    if (index !== undefined && (!insert || index > insert.index)) return { type: 'patch', index }
+    return insert ?? { type: 'file' }
   }
 
   fileOwned(id: string, key: string | null) {
@@ -238,12 +240,6 @@ export function routeJournal(journal: Journal, data: EntryOptions[], patches: Pa
       continue
     }
 
-    if (owner.type === 'insert') {
-      applyChanges(current.options, record.changes)
-      patched = true
-      continue
-    }
-
     const patchChanges: Dict<Dict> = {}
     applyChanges(current.options, record.changes, (key) => {
       const keyOwner = index.key(id, key)
@@ -251,6 +247,7 @@ export function routeJournal(journal: Journal, data: EntryOptions[], patches: Pa
       ;(patchChanges[keyOwner.index] ??= {})[key] = record.changes[key]
       return false
     })
+    if (owner.type === 'insert') patched = true
     for (const [i, changes] of Object.entries(patchChanges)) {
       applyChanges(patches[i] as any, changes)
       patched = true

--- a/packages/include/tests/patch-owner.spec.ts
+++ b/packages/include/tests/patch-owner.spec.ts
@@ -1,0 +1,73 @@
+import { expect, describe, it } from 'vitest'
+import { readFile, writeFile } from 'node:fs/promises'
+import * as yaml from 'js-yaml'
+import Include from '../src'
+import type { PatchOptions } from '../src/patch'
+import { fixture, harness, plugin } from './utils'
+
+describe('Include inserted-entry overrides', () => {
+  const { setup } = harness()
+
+  const config = (value: number) => ({ tag: 'x', value })
+  const scenarios: { name: string; patches: PatchOptions[]; expected: PatchOptions[]; initial: number }[] = [
+    {
+      name: 'last override',
+      patches: [{ insert: [plugin('x', 1)] }, { id: 'x', config: config(2) }],
+      expected: [{ insert: [plugin('x', 1, { disabled: false })] }, { id: 'x', config: config(3) }],
+      initial: 2,
+    },
+    {
+      name: 'multiple overrides',
+      patches: [{ insert: [plugin('x', 1)] }, { id: 'x', config: config(0) }, { id: 'x', config: config(2) }],
+      expected: [{ insert: [plugin('x', 1, { disabled: false })] }, { id: 'x', config: config(0) }, { id: 'x', config: config(3) }],
+      initial: 2,
+    },
+    {
+      name: 'insertion without overrides',
+      patches: [{ insert: [plugin('x', 1)] }],
+      expected: [{ insert: [plugin('x', 3, { disabled: false })] }],
+      initial: 1,
+    },
+    {
+      name: 'skipped override before insertion',
+      patches: [{ id: 'x', config: config(2) }, { insert: [plugin('x', 1)] }],
+      expected: [{ id: 'x', config: config(2) }, { insert: [plugin('x', 3, { disabled: false })] }],
+      initial: 1,
+    },
+    {
+      name: 'skipped name mismatch',
+      patches: [{ insert: [plugin('x', 1)] }, { id: 'x', config: config(2) }, { id: 'x', name: 'wrong-plugin', config: config(9) }],
+      expected: [{ insert: [plugin('x', 1, { disabled: false })] }, { id: 'x', config: config(3) }, { id: 'x', name: 'wrong-plugin', config: config(9) }],
+      initial: 2,
+    },
+  ]
+
+  for (const scenario of scenarios) {
+    it(`persists each key to its effective owner (${scenario.name})`, async () => {
+      const inner = fixture('tmp-owner-inner.yml')
+      const innerText = yaml.dump([plugin('a', 1)])
+      await writeFile(inner, innerText)
+      const app = await setup('tmp-owner-outer.yml', [{
+        id: 'inc',
+        name: '@cordisjs/plugin-include',
+        config: {
+          path: './tmp-owner-inner.yml',
+          patches: scenario.patches,
+        },
+      }])
+      app.files.push(inner)
+      const include = () => app.include().store['inc']!.subtree as Include
+      expect(app.config('x').value).toBe(scenario.initial)
+
+      await app.update('inc:x', { config: config(3), disabled: false })
+      await include().refresh()
+      await app.settle()
+
+      expect(app.config('x').value).toBe(3)
+      const [entry] = await app.read()
+      expect(entry.config.patches).toEqual(scenario.expected)
+      expect(await readFile(inner, 'utf8')).toBe(innerText)
+      expect(app.logs('error')).toEqual([])
+    })
+  }
+})


### PR DESCRIPTION
Closes #129.

When a patch inserts an entry and a later patch overrides its config, `loader.update()` currently saves runtime changes in the insertion. Reapplying the later override then silently restores the old value (e.g. `2 → 3 → 2`). This is a follow-up to #121's synchronization model.

Route each key to its last effective override, falling back to the insertion for keys with no override. Overrides before insertion or with a mismatched plugin name remain ignored. The five nested-Include tests verify the live value, the saved parent patches, and unchanged child-file bytes; three fail on the original code with `expected 2 to be 3`.

Validation: full `yarn test:json` on Node 24.19.0 and 26.7.0 (253 tests each), `yarn build core && yarn build`, `yarn lint`, and `git diff --check`. [Fork CI for this commit](https://github.com/Adkid-Zephyr/cordis/actions/runs/34175189741) also passed all eight jobs: Linux/Windows/macOS × Node 24/26, build, and lint. AI-assisted implementation and tests.
