### PR TITLE
fix(core): surface the first cause in parallel AggregateError

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -90,7 +90,11 @@ export class EventsService {
     const [thisArg, callbacks] = this._resolve('emit', args)
     const results = await Promise.allSettled(callbacks.map(async callback => Reflect.apply(callback, thisArg, args)))
     const errors = results.filter((result): result is PromiseRejectedResult => result.status === 'rejected')
-    if (errors.length) throw new AggregateError(errors.map(error => error.reason))
+    if (errors.length) {
+      // surface the first cause so that a dropped rejection is readable on
+      // its own, without digging into the `errors` array
+      throw new AggregateError(errors.map(error => error.reason), errors[0].reason?.message ?? String(errors[0].reason))
+    }
   }
 
   emit(...args: any[]) {

--- a/packages/core/tests/events.spec.ts
+++ b/packages/core/tests/events.spec.ts
@@ -279,4 +279,17 @@ describe('Events', () => {
     expect(callback.mock.calls).to.have.length(2)
     expect(terminal.mock.calls).to.have.length(2)
   })
+
+  it('ctx.parallel() rejects with a readable AggregateError', async () => {
+    const { root } = setup()
+    root.on(event, async () => {
+      throw new Error('async listener blew up')
+    })
+
+    const error = await root.parallel(event).catch(e => e)
+    // the rejection must be readable on its own, without digging into `errors`
+    expect(error).to.be.instanceof(AggregateError)
+    expect(error.message).to.include('async listener blew up')
+    expect(error.errors.map((e: Error) => e.message)).to.have.members(['async listener blew up'])
+  })
 })


### PR DESCRIPTION
A listener that fails asynchronously is routine, and plugins commonly  
fire-and-forget the call:

```ts
ctx.on('boom', async () => { throw new Error('async listener blew up') })
void ctx.parallel('boom').catch(e => console.log(e.message))
// logs: ""
```

`parallel()` rejects with an `AggregateError` whose message is empty.

Passing the error through the cordis logger is already fine — the logger
expands an AggregateError into its causes. The gap is anything that reads
the message: `String(e)` reads just `"AggregateError"`, so log aggregation
groups every `parallel()` failure into one indistinguishable bucket; the
actual cause is only visible inside the stack's `errors` array.

Give the error the first cause's message. `e.errors` is unchanged.

```ts
throw new AggregateError(errors.map(error => error.reason),
  errors[0].reason?.message ?? String(errors[0].reason))
```

A test added to `events.spec.ts` asserts a rejected `parallel()` carries the listener's message,
and the full core suite passes.
