### PR TITLE
fix(core): settle disposed fibers to DISPOSED

### DIFF
--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -195,6 +195,7 @@ export class Fiber {
           while (this.inertia) {
             await this.inertia
           }
+          this._updateState(() => {})
         }
       }, 'ctx.plugin()')
     } else {

--- a/packages/core/tests/fiber.spec.ts
+++ b/packages/core/tests/fiber.spec.ts
@@ -162,6 +162,94 @@ describe('Fiber', () => {
     expect(error.mock.calls).to.have.length(1)
   })
 
+  it('settles a pending fiber to DISPOSED on dispose', async () => {
+    const root = new Context()
+    const fiber = root.inject(['never-provided'], () => {})
+    const target = Object.getPrototypeOf(fiber)
+    const transitions: [FiberState, FiberState][] = []
+    const off = root.on('internal/status', (current, oldState) => {
+      if (current === target) {
+        transitions.push([oldState, current.state])
+      }
+    })
+
+    try {
+      expect(fiber.state).to.equal(FiberState.PENDING)
+
+      await fiber.dispose()
+
+      expect(fiber.uid).to.equal(null)
+      expect(fiber.inertia).to.equal(undefined)
+      expect(fiber.state).to.equal(FiberState.DISPOSED)
+      expect(transitions).to.deep.equal([
+        [FiberState.PENDING, FiberState.DISPOSED],
+      ])
+    } finally {
+      off()
+    }
+  })
+
+  it('settles a failed fiber to DISPOSED on dispose', async () => {
+    const root = new Context()
+    ;(root.logger as any).error = mock.fn()
+
+    const fiber = root.plugin(() => {
+      throw new Error('boom')
+    })
+    const target = Object.getPrototypeOf(fiber)
+    const transitions: [FiberState, FiberState][] = []
+
+    await expect(fiber.await()).rejects.toThrow('boom')
+    expect(fiber.state).to.equal(FiberState.FAILED)
+
+    const off = root.on('internal/status', (current, oldState) => {
+      if (current === target) {
+        transitions.push([oldState, current.state])
+      }
+    })
+
+    try {
+      await fiber.dispose()
+
+      expect(fiber.uid).to.equal(null)
+      expect(fiber.inertia).to.equal(undefined)
+      expect(fiber.state).to.equal(FiberState.DISPOSED)
+      expect(transitions).to.deep.equal([
+        [FiberState.FAILED, FiberState.DISPOSED],
+      ])
+    } finally {
+      off()
+    }
+  })
+
+  it('keeps the active dispose sequence stable', async () => {
+    const root = new Context()
+    const fiber = root.plugin(() => {})
+    await fiber.await()
+
+    const target = Object.getPrototypeOf(fiber)
+    const transitions: [FiberState, FiberState][] = []
+    const off = root.on('internal/status', (current, oldState) => {
+      if (current === target) {
+        transitions.push([oldState, current.state])
+      }
+    })
+
+    try {
+      await fiber.dispose()
+
+      expect(fiber.uid).to.equal(null)
+      expect(fiber.inertia).to.equal(undefined)
+      expect(fiber.state).to.equal(FiberState.DISPOSED)
+      expect(transitions).to.deep.equal([
+        [FiberState.ACTIVE, FiberState.UNLOADING],
+        [FiberState.UNLOADING, FiberState.DISPOSED],
+      ])
+    } finally {
+      off()
+    }
+  })
+
   it('update config on wrapped fiber', async () => {
     const root = new Context()
     const callback = mock.fn()


### PR DESCRIPTION
Fixes #127.

## Summary

A Fiber that reaches terminal disposal from PENDING or FAILED can retain a stale cached state after `dispose()` completes. This patch refreshes the cached state at the terminal disposer boundary, after the lifecycle task chain has drained.

## Root cause

The terminal disposer sets `uid = null` and calls `_setEpoch(INACTIVE)`. For a PENDING Fiber, the epoch is already INACTIVE; for a FAILED Fiber, `_error` short-circuits the epoch transition. In both cases, the existing state refresh is skipped.

`_getState()` already defines `uid === null` as `FiberState.DISPOSED`.

## Change

Add one `_updateState(() => {})` call after the terminal disposer waits for `inertia` to settle.

This reuses the existing state mapping and status event path while keeping the public API, FiberState enum, epoch scheduling, reload/unload behavior, and error storage unchanged.

## Regression coverage

The tests cover:

- `PENDING -> DISPOSED` after disposing a Fiber waiting on a missing dependency;
- `FAILED -> DISPOSED` after plugin execution failure;
- `ACTIVE -> UNLOADING -> DISPOSED` existing lifecycle behavior;
- `uid === null`, `inertia === undefined`, and the public wrapper state;
- exactly one terminal `internal/status` transition for each terminal case.

## Validation

- Baseline: `corepack yarn test core` produced 2 expected failures in the new regression cases and 88 passing tests.
- `corepack yarn test core`: 12 files, 90 tests passed.
- `corepack yarn test`: 25 files, 251 tests passed.
- `corepack yarn test:json`: 25 files, 251 tests passed with coverage enabled.
- `corepack yarn lint`
- `corepack yarn build core`
- `corepack yarn build`
- `git diff --check`

The pull request changes only `packages/core/src/fiber.ts` and `packages/core/tests/fiber.spec.ts`.
