### PR TITLE
fix(core): report parallel dispatch mode

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -87,7 +87,7 @@ export class EventsService {
   }
 
   async parallel(...args: any[]) {
-    const [thisArg, callbacks] = this._resolve('emit', args)
+    const [thisArg, callbacks] = this._resolve('parallel', args)
     const results = await Promise.allSettled(callbacks.map(async callback => Reflect.apply(callback, thisArg, args)))
     const errors = results.filter((result): result is PromiseRejectedResult => result.status === 'rejected')
     if (errors.length) throw new AggregateError(errors.map(error => error.reason))

--- a/packages/core/tests/events.spec.ts
+++ b/packages/core/tests/events.spec.ts
@@ -100,6 +100,17 @@ describe('Events', () => {
     expect(callback.mock.calls).to.have.length(1)
   })
 
+  it('ctx.parallel() reports the parallel dispatch mode', async () => {
+    const { root } = setup()
+    const dispatch = mock.fn()
+
+    root.on('internal/dispatch', dispatch)
+    await root.parallel(event)
+
+    expect(dispatch.mock.calls).to.have.length(1)
+    expect(dispatch.mock.calls[0].arguments[0]).to.equal('parallel')
+  })
+
   it('ctx.parallel()', async () => {
     const { root } = setup()
     await root.parallel(event)


### PR DESCRIPTION
## Problem

`ctx.parallel()` currently reports `emit` to `internal/dispatch`, even though
`DispatchMode` includes a distinct `parallel` value.

The mode was originally `parallel`. The callback-tracing refactor in
`cb0d85d` changed the dispatch call to `emit`, and later event refactors
preserved that value.

## Change

Pass `parallel` into `_resolve()` from `EventsService.parallel()`.

This restores the original dispatch identity and keeps listener execution,
aggregation, filtering, and error handling intact.

## Regression coverage

The new test observes `internal/dispatch` while calling `ctx.parallel()` and
asserts that the reported mode is `parallel`.

## Validation

- `corepack yarn test core`
- `corepack yarn test`
- `corepack yarn test:json`
- `corepack yarn lint`
- `corepack yarn build core`
- `corepack yarn build`
- `git diff --check origin/main...HEAD`