### PR TITLE
fix(core): align internal listener event types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
         run: yarn --no-immutable
       - name: Build (1)
         run: yarn build core
+      - name: Type Test
+        run: yarn test:types:core
       - name: Build (2)
         run: yarn build
       - name: Publish

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "yarn yakumo vitest --import tsx",
     "test:text": "shx rm -rf coverage && yarn test --coverage --coverage.reporter text",
     "test:json": "shx rm -rf coverage && yarn test --coverage --coverage.reporter json",
-    "test:html": "shx rm -rf coverage && yarn test --coverage --coverage.reporter html"
+    "test:html": "shx rm -rf coverage && yarn test --coverage --coverage.reporter html",
+    "test:types:core": "yarn exec tsc -p packages/core/tests/tsconfig.consumer.json"
   },
   "devDependencies": {
     "@cordisjs/eslint-config": "^1.1.1",

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -183,6 +183,6 @@ export interface Events {
   'internal/update'(this: Fiber, config: any, noSave: boolean, next: () => Awaitable<void>): Awaitable<void>
   'internal/get'(ctx: Context, name: string, error: Error, next: () => any): any
   'internal/set'(ctx: Context, name: string, value: any, error: Error, next: () => boolean): boolean
-  'internal/listener'(this: Context, name: string, listener: any, prepend: boolean): void
+  'internal/listener'(this: Context, name: string | symbol, listener: any, options: EventOptions): void
   'internal/dispatch'(mode: DispatchMode, name: string | symbol, args: any[], thisArg: any): void
 }

--- a/packages/core/tests/events.consumer.types.ts
+++ b/packages/core/tests/events.consumer.types.ts
@@ -1,0 +1,13 @@
+import { Context } from 'cordis'
+
+declare const ctx: Context
+
+ctx.on('internal/listener', (name, listener, options) => {
+  if (typeof name === 'symbol') {
+    name.description
+  }
+
+  listener
+  options.prepend
+  options.global
+})

--- a/packages/core/tests/tsconfig.consumer.json
+++ b/packages/core/tests/tsconfig.consumer.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "../../..",
+    "noEmit": true,
+    "composite": false,
+    "incremental": false,
+    "paths": {
+      "cordis": ["packages/core/lib/index.d.ts"]
+    }
+  },
+  "files": ["events.consumer.types.ts"]
+}


### PR DESCRIPTION
## Problem

The `internal/listener` event declaration still describes the original
registration payload:

```ts
name: string
prepend: boolean
```

The runtime has evolved in two steps:

- event options now reach the hook as `EventOptions`
- event names now support `string | symbol`

The declaration retained the older shape across both changes.

## Change

Align the `internal/listener` event declaration with the payload already sent
by `EventsService.on()`:

```ts
name: string | symbol
options: EventOptions
```

Runtime behavior stays the same.

## Regression coverage

Add an emitted declaration consumer fixture to exercise:

- symbol-aware listener names
- `options.prepend`
- `options.global`

The fixture imports `Context` from the `cordis` package entry and is compiled
through a dedicated `test:types:core` script after `build core`.

## Validation

- source diagnostic delta for `packages/core/tests/events.types.ts`
- `corepack yarn build core` + `corepack yarn test:types:core` exit `0`
- `corepack yarn test core`
- `corepack yarn test`
- `corepack yarn test:json`
- `corepack yarn lint`
- `corepack yarn build core`
- `corepack yarn build`
- `git diff --check origin/main...HEAD`