### PR TITLE
fix(core): tear down disposables serially, dependent first

### DIFF
--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -437,7 +437,13 @@ export class Fiber {
   }
 
   private async _unload() {
-    await Promise.all(this._disposables.clear().map(async (dispose) => {
+    // clear() yields disposables in reverse registration order: dependents
+    // are registered after their dependencies, so a dependent's async
+    // teardown settles before the dependency is torn down. Running them
+    // concurrently (Promise.all) let a dependency finish teardown while a
+    // dependent was still winding down (#26), e.g. logging after the logger
+    // service closed its stream.
+    for (const dispose of this._disposables.clear()) {
       try {
         await composeError(async (info) => {
           await Promise.resolve()
@@ -447,7 +453,7 @@ export class Fiber {
       } catch (reason) {
         this.ctx.logger.error(reason)
       }
-    }))
+    }
     this.store = undefined
     this._updateState(() => {
       if (this._runner.epoch === INACTIVE) {

--- a/packages/core/tests/dispose.spec.ts
+++ b/packages/core/tests/dispose.spec.ts
@@ -1,4 +1,4 @@
-import { Context } from '../src'
+import { Context, Service } from '../src'
 import { expect, describe, it, vi } from 'vitest'
 import { mock } from 'node:test'
 import { sleep, withTimers } from './utils'
@@ -237,4 +237,46 @@ describe('Effects', () => {
     expect(caught).to.be.instanceOf(Error)
     expect(seq).to.deep.equal([1])
   })
+
+  // a dependent (injecting a service) is registered after its dependency, so
+  // unload must let the dependent's async teardown settle before tearing the
+  // dependency down (#26)
+  it('dependent async teardown settles before its dependency (#26)', withTimers(async (root) => {
+    const timeline: string[] = []
+    class Writer extends Service {
+      closed = false
+
+      constructor(ctx: Context) {
+        super(ctx, 'writer')
+      }
+
+      *[Service.init]() {
+        yield () => {
+          this.closed = true
+          timeline.push('closed')
+        }
+      }
+
+      log(message: string) {
+        timeline.push(`${message}:${this.closed}`)
+      }
+    }
+    const fiber = root.plugin((ctx) => {
+      ctx.plugin(Writer)
+      ctx.inject(['writer'], (c) => {
+        c.effect(() => {
+          c.writer.log('start')
+          return async () => {
+            await sleep(3000)
+            c.writer.log('end')
+          }
+        })
+      })
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    const pending = fiber.dispose()
+    await vi.advanceTimersByTimeAsync(3000)
+    await pending
+    expect(timeline).to.deep.equal(['start:false', 'end:false', 'closed'])
+  }))
 })


### PR DESCRIPTION
Fixes #26

## Summary

`_unload()` ran disposables with `Promise.all`. Sibling disposables are torn down in reverse registration order, but parallel teardown let a dependency finish its async dispose while an earlier-registered dependent was still winding down — so the dependent's cleanup could touch already-closed shared resources (e.g. a stream closed before a long-running effect finished).

This change clears and awaits disposables one at a time in reverse registration order (dependents register after their dependencies, so dependents wind down first). Timeline for the regression scenario becomes `['start:false', 'end:false', 'closed']` instead of `['start:false', 'closed', 'end:true']`.

## Testing

- One regression spec in `packages/core/tests/dispose.spec.ts` asserting the teardown order.
- Independently verified with a standalone runtime harness (3s teardown effect + Writer service): bug reproduces on `main`, fix confirmed on this branch.
- `yarn yakumo tsc` (all packages) and eslint pass.
- Full vitest suite is exercised by CI (local runner unavailable on this host's platform).
