### PR TITLE
fix(include): route runtime changes on overridden inserted entries to the last override

### DIFF
--- a/packages/include/src/patch.ts
+++ b/packages/include/src/patch.ts
@@ -170,12 +170,13 @@ export class PatchIndex {
     return this.inserts.get(id) ?? { type: 'file' }
   }
 
-  /** Owner of one key of an entry. */
+  /** Owner of one key of an entry: the last override wins, then the insertion, then the file. */
   key(id: string, key: string): EntryOwner {
+    const index = this.keys.get(id)?.get(key)
+    if (index !== undefined) return { type: 'patch', index }
     const insert = this.inserts.get(id)
     if (insert) return insert
-    const index = this.keys.get(id)?.get(key)
-    return index === undefined ? { type: 'file' } : { type: 'patch', index }
+    return { type: 'file' }
   }
 
   fileOwned(id: string, key: string | null) {
@@ -239,8 +240,23 @@ export function routeJournal(journal: Journal, data: EntryOptions[], patches: Pa
     }
 
     if (owner.type === 'insert') {
-      applyChanges(current.options, record.changes)
-      patched = true
+      // per-key overrides still win over the insertion (last owner, as when reading)
+      const patchChanges: Dict<Dict> = {}
+      let inserted = false
+      applyChanges(current.options, record.changes, (key) => {
+        const keyOwner = index.key(id, key)
+        if (keyOwner.type === 'patch') {
+          ;(patchChanges[keyOwner.index] ??= {})[key] = record.changes[key]
+          return false
+        }
+        inserted = true
+        return true
+      })
+      for (const [i, changes] of Object.entries(patchChanges)) {
+        applyChanges(patches[i] as any, changes)
+        patched = true
+      }
+      if (inserted) patched = true
       continue
     }
 

--- a/packages/include/tests/sync.spec.ts
+++ b/packages/include/tests/sync.spec.ts
@@ -203,6 +203,42 @@ describe('Include sync', () => {
     expect(entry.config.patches).toEqual([{ insert: [plugin('x', 2)] }])
   }, 10000)
 
+  it('routes changes to an overridden inserted entry into the override (#129)', async () => {
+    const inner = fixture('tmp-sync-inner-override.yml')
+    const innerText = yaml.dump([plugin('a', 1)])
+    await writeFile(inner, innerText)
+    const app = await setup('tmp-sync-outer-override.yml', [{
+      id: 'inc',
+      name: '@cordisjs/plugin-include',
+      config: {
+        path: './tmp-sync-inner-override.yml',
+        patches: [
+          { insert: [plugin('x', 1)] },
+          { id: 'x', config: { tag: 'x', value: 2 } },
+        ],
+      },
+    }])
+    app.files.push(inner)
+    const innerInclude = () => app.include().store['inc']!.subtree as Include
+    await innerInclude().refresh()
+    await app.ctx.loader.await()
+    expect(app.config('x').value).toBe(2)
+
+    await app.update('inc:x', { config: { tag: 'x', value: 3 } })
+    await innerInclude().refresh()
+    await app.settle()
+
+    // the runtime value and the last effective override become 3; the
+    // insertion and the child file stay untouched
+    expect(app.config('x').value).toBe(3)
+    expect(await readFile(inner, 'utf8')).toBe(innerText)
+    const [entry] = await app.read()
+    expect(entry.config.patches).toEqual([
+      { insert: [plugin('x', 1)] },
+      { id: 'x', config: { tag: 'x', value: 3 } },
+    ])
+  }, 10000)
+
   it('keeps anonymous entries stable across reloads without writing', async () => {
     const anonymous = { name: './config-plugin', config: { tag: 'anon', value: 1 } }
     const text = yaml.dump([anonymous, plugin('b', 1)])


### PR DESCRIPTION
Fixes #129

## Summary

Runtime changes on an entry that was inserted by one patch and later overridden by another patch were routed entirely to the insert, discarding the override. This change implements per-key ownership:

- Keys covered by an override are routed to the last override patch.
- Non-overridden keys of the inserted entry still apply to the insert itself.
- Reads already resolve overrides via the override table first; this aligns the runtime-change write path with that read semantics.

## Testing

- One regression spec in `packages/include/tests/sync.spec.ts` (nested include; an inserted-then-overridden entry is updated via the last override while the inner config file stays untouched).
- `yarn yakumo tsc` (all packages) and eslint pass.
- Full vitest suite is exercised by CI (local runner unavailable on this host's platform).
