### PR TITLE
fix(core): apply updates issued while a fiber is loading

### DIFF
--- a/packages/core/src/fiber.ts
+++ b/packages/core/src/fiber.ts
@@ -118,6 +118,17 @@ export class Fiber {
   private _error: any
   private _runner: EffectRunner<string>
   private _store: Dict<Impl> = Object.create(null)
+  // bumped by every explicit `restart()` request. A lifecycle task snapshots
+  // it when it starts: if it has advanced by the time the task settles, a
+  // teardown-and-reapply was requested while the task was running, even when
+  // the epoch string happens to equal the snapshot (restart() toggles the
+  // epoch through `INACTIVE` and back, e.g. `'' -> INACTIVE -> ''` during a
+  // load). Comparing the raw epoch alone would miss such ABA sequences and
+  // silently swallow the request — an `update()` issued during `LOADING`
+  // would update `fiber.config` yet never re-run the plugin with it.
+  // Dependency churn that resolves to the same epoch before settle is *not*
+  // tracked here: it is deliberately tolerated (see the "inertia lock" tests).
+  private _generation = 0
 
   constructor(
     public parent: Context,
@@ -417,6 +428,7 @@ export class Fiber {
   private async _reload() {
     this.store = { ...this._store }
     const oldEpoch = this._runner.epoch
+    const oldGeneration = this._generation
     try {
       await Promise.resolve()
       await this._execute(this._runner)
@@ -427,7 +439,7 @@ export class Fiber {
       this._runner.epoch = INACTIVE
     }
     this._updateState(() => {
-      if (this._runner.epoch === oldEpoch) {
+      if (this._runner.epoch === oldEpoch && this._generation === oldGeneration) {
         this.inertia = undefined
       } else {
         this.inertia = this._unload()
@@ -470,6 +482,9 @@ export class Fiber {
   async restart() {
     const fiber = this.ctx.fiber
     fiber.assertActive()
+    // mark this explicit request so an in-flight lifecycle task does not
+    // mistake it for a no-op when the epoch returns to its previous value
+    fiber._generation++
     fiber._setEpoch(INACTIVE)
     fiber._refresh()
     await fiber.await()

--- a/packages/core/tests/fiber.spec.ts
+++ b/packages/core/tests/fiber.spec.ts
@@ -182,6 +182,107 @@ describe('Fiber', () => {
     expect(callback.mock.calls[2].arguments[1]).to.deep.equal({ msg: '!!!' })
   })
 
+  // regression test for #34: an update() issued while the fiber is still
+  // LOADING toggles the epoch through INACTIVE and back ('' -> INACTIVE -> '');
+  // the in-flight reload used to compare the epoch value at settle, mistook the
+  // ABA for "no change" and cleared its inertia — fiber.config was updated but
+  // the plugin never re-ran with the new config.
+  it('applies an update issued while the fiber is still loading', async () => {
+    const applied: number[] = []
+    let markStarted!: () => void
+    let release!: () => void
+    const started = new Promise<void>(resolve => { markStarted = resolve })
+    const gate = new Promise<void>(resolve => { release = resolve })
+
+    const root = new Context()
+    const wrapped = root.plugin(async (_, config: { value: number }) => {
+      applied.push(config.value)
+      if (config.value === 1) {
+        markStarted()
+        await gate
+      }
+    }, { value: 1 })
+
+    await started
+    const fiber = Object.getPrototypeOf(wrapped)
+    expect(fiber.state).to.equal(FiberState.LOADING)
+
+    const updating = fiber.update({ value: 2 })
+    release()
+    await updating
+
+    expect(applied).to.deep.equal([1, 2])
+    expect(fiber.config).to.deep.equal({ value: 2 })
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+  })
+
+  it('coalesces concurrent updates issued during loading to the latest config', async () => {
+    const applied: number[] = []
+    let markStarted!: () => void
+    let release!: () => void
+    const started = new Promise<void>(resolve => { markStarted = resolve })
+    const gate = new Promise<void>(resolve => { release = resolve })
+
+    const root = new Context()
+    const wrapped = root.plugin(async (_, config: { value: number }) => {
+      applied.push(config.value)
+      if (config.value === 1) {
+        markStarted()
+        await gate
+      }
+    }, { value: 1 })
+
+    await started
+    const fiber = Object.getPrototypeOf(wrapped)
+
+    const updates = Promise.all([
+      fiber.update({ value: 2 }),
+      fiber.update({ value: 3 }),
+    ])
+    release()
+    await updates
+
+    // the intermediate config is superseded before the follow-up load runs
+    expect(applied).to.deep.equal([1, 3])
+    expect(fiber.config).to.deep.equal({ value: 3 })
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+  })
+
+  it('applies an update issued while an injected fiber is still loading', async () => {
+    const applied: string[] = []
+    let markStarted!: () => void
+    let release!: () => void
+    const started = new Promise<void>(resolve => { markStarted = resolve })
+    const gate = new Promise<void>(resolve => { release = resolve })
+
+    const plugin = {
+      inject: ['foo'],
+      apply: async (ctx: Context, config: { mode: string }) => {
+        applied.push(`${config.mode}:${ctx.foo}`)
+        if (config.mode === 'old') {
+          markStarted()
+          await gate
+        }
+      },
+    }
+
+    const root = new Context()
+    root.provide('foo', 1)
+    const wrapped = root.plugin(plugin, { mode: 'old' })
+
+    await started
+    const fiber = Object.getPrototypeOf(wrapped)
+    expect(fiber.state).to.equal(FiberState.LOADING)
+
+    const updating = fiber.update({ mode: 'new' })
+    release()
+    await updating
+
+    expect(applied).to.deep.equal(['old:1', 'new:1'])
+    expect(fiber.config).to.deep.equal({ mode: 'new' })
+    expect(fiber.state).to.equal(FiberState.ACTIVE)
+  })
+
   it('restart wrapped fiber', async () => {
     const root = new Context()
     const callback = mock.fn()


### PR DESCRIPTION
Fixes #34

## Problem and fix
An update() issued while a fiber is LOADING writes the new config, but
restart() toggles the dependency epoch through INACTIVE and back. The
in-flight _reload() then sees the original epoch and clears inertia without
applying the new config: applied is [1] while config.value is 2.

Track explicit restart() requests with a generation counter. _reload()
snapshots both epoch and generation; a restart during loading schedules
teardown and reapply even if the epoch returns to its original value.
The reproduction now produces [1, 2], and awaiting update() observes the
applied configuration.

## Relationship to existing proposals
Related: https://github.com/cordiverse/cordis/pull/54 and
https://github.com/cordiverse/cordis/pull/143 (both open as of 2026-09-09).
This is an alternative with a narrower scope for the same issue.

- #143 increments generation whenever _setEpoch accepts an epoch change.
  This implementation increments it only for explicit restart() requests,
  including those made by update(). Dependency churn that returns to the
  same epoch remains tolerated, preserving the existing inertia lock 2 test.
- #54 also tracks epoch transitions and guards execution, async-generator
  continuation, and error publication against stale generations. It changes
  failure/recovery behavior as well. This implementation preserves the
  existing contract: if the old load throws while an update is pending,
  update() rejects and the fiber settles FAILED.

All 12 existing fiber tests, including inertia lock 1/2/3, are unchanged.
Whether dependency ABA should also invalidate loading work is a separate
semantic decision for maintainers. PR #134 is an adjacent config-resolution
change and should also be considered when integrating lifecycle changes.

## Validation
Three new regression tests cover update during loading, concurrent updates
coalescing to the latest config, and an injected fiber. Each asserts applied
configuration and ACTIVE state after awaiting the update(s). The single-update
and injected cases explicitly assert LOADING; the concurrent case establishes
that window through Promise gates.

- Core: 90/90 passing; fiber.spec.ts: 15/15.
- Core + timer + group + logger-console + utils: 113/113 passing.
- Whole repository using the local alias config: baseline 172 passed,
  35 failed, 41 skipped; fixed 175 passed, 35 failed, 41 skipped.
  The failing test names are identical in both versions, confined to four
  include test files and one hmr test file. This is not a fully green run.
- Before/after failure probe: update() rejects and the fiber settles FAILED
  when the old load throws. This probe is not a committed regression test.
- Source ESLint and git diff --check pass.

Standard CI must pass lint, build/type checks, and the complete test suite
before merge. The local alias-config runs do not replace standard CI;
the normal yarn test workflow remains unverified in this sandbox.

## Compatibility
No public API signature changes. Existing dependency ABA and load-failure
semantics are preserved.
