### PR TITLE
fix(logger-console): align multiline message indentation

### DIFF
--- a/packages/logger-console/src/shared.ts
+++ b/packages/logger-console/src/shared.ts
@@ -77,12 +77,13 @@ export class ConsoleExporter implements Exporter {
     const code = Logger.code(message.name, this.colors)
     const label = Logger.color(this, code, message.name, ';1')
     const padLength = (this.label?.width ?? 0) + label.length - message.name.length
+    const labelWidth = Math.max(this.label?.width ?? 0, message.name.length)
     if (this.label?.align === 'right') {
       output += label.padStart(padLength) + space + prefix + space
-      indent += (this.label.width ?? 0) + space.length
     } else {
       output += prefix + space + label.padEnd(padLength) + space
     }
+    indent += labelWidth + space.length
     output += Logger.format(this, message).replace(/\n/g, '\n' + ' '.repeat(indent))
     if (this.showDiff && this.timestamp) {
       const diff = message.ts - this.timestamp

--- a/packages/logger-console/tests/index.spec.ts
+++ b/packages/logger-console/tests/index.spec.ts
@@ -56,11 +56,38 @@ describe('logger-console', () => {
     expect(data).toBeTruthy()
   })
 
+  it('multiline messages', () => {
+    exporter.label = undefined
+    ctx.logger('test').info('message\nmessage')
+    expect(data).toBe([
+      '[I] test message\n',
+      '         message +0ms\n',
+    ].join(''))
+  })
+
   it('label style', () => {
     exporter.label = { align: 'right', width: 10, margin: 2 }
     ctx.logger('test').info('message\nmessage')
     expect(data).toBe([
       '      test  [I]  message\n',
+      '                 message +0ms\n',
+    ].join(''))
+  })
+
+  it('label style with a narrow width', () => {
+    exporter.label = { align: 'right', width: 2, margin: 2 }
+    ctx.logger('test').info('message\nmessage')
+    expect(data).toBe([
+      'test  [I]  message\n',
+      '           message +0ms\n',
+    ].join(''))
+  })
+
+  it('left-aligned label style', () => {
+    exporter.label = { align: 'left', width: 10, margin: 2 }
+    ctx.logger('test').info('message\nmessage')
+    expect(data).toBe([
+      '[I]  test        message\n',
       '                 message +0ms\n',
     ].join(''))
   })


### PR DESCRIPTION
## Summary

- align continuation lines with the message body for default and left-aligned logger labels
- use the effective label width when a right-aligned label is narrower than its logger name
- add regressions for multiline output in each case

## Validation

- `corepack yarn test logger-console`
- `corepack yarn test`
- `corepack yarn lint`
- `corepack yarn build core && corepack yarn build`